### PR TITLE
Transform code to use xp-forge/partial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - hhvm
   - nightly

--- a/README.md
+++ b/README.md
@@ -16,27 +16,30 @@ Example
 Given the following two value objects:
 
 ```php
-class Book extends \lang\Object { use \util\objects\CreateWith;
+use lang\partial\ValueObject;
+use lang\partial\WithCreation;
+
+class Book extends \lang\Object {
+  use Book\including\ValueObject;
+  use Book\including\WithCreation;
+
   private $name, $author;
 
   public function __construct($name, Author $author) {
     $this->name= $name;
     $this->author= $author;
   }
-
-  public function name() { return $this->name; }
-
-  public function author() { return $this->author; }
 }
 
-class Author extends \lang\Object { use \util\objects\CreateWith;
+class Author extends \lang\Object {
+  use Author\including\ValueObject;
+  use Author\including\WithCreation;
+
   private $name;
 
   public function __construct($name) {
     $this->name= $name;
   }
-
-  public function name() { return $this->name; }
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.0",
-    "xp-forge/creation" : "~0.2",
+    "xp-forge/partial" : "^0.4.0",
     "php" : ">=5.4.0"
   },
   "autoload" : {

--- a/src/main/php/util/address/CreationOf.class.php
+++ b/src/main/php/util/address/CreationOf.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\address;
 
-use util\objects\InstanceCreation;
+use lang\partial\InstanceCreation;
 
 /**
  * Creates an object based on a given instance creation

--- a/src/test/php/util/address/unittest/Author.class.php
+++ b/src/test/php/util/address/unittest/Author.class.php
@@ -1,8 +1,12 @@
 <?php namespace util\address\unittest;
 
-use util\Objects;
+use lang\partial\ValueObject;
+use lang\partial\WithCreation;
 
-class Author extends \lang\Object { use \util\objects\CreateWith;
+class Author extends \lang\Object {
+  use Author\including\ValueObject;
+  use Author\including\WithCreation;
+
   private $name;
 
   /**
@@ -12,27 +16,5 @@ class Author extends \lang\Object { use \util\objects\CreateWith;
    */
   public function __construct($name) {
     $this->name= $name;
-  }
-
-  /** @return string */
-  public function name() { return $this->name; }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return $this->getClassName().'@'.Objects::stringOf(get_object_vars($this));
-  }
-
-  /**
-   * Checks for equality
-   *
-   * @param  var $value
-   * @return bool
-   */
-  public function equals($value) {
-    return $value instanceof self && $this->name === $value->name;
   }
 }

--- a/src/test/php/util/address/unittest/Book.class.php
+++ b/src/test/php/util/address/unittest/Book.class.php
@@ -1,8 +1,12 @@
 <?php namespace util\address\unittest;
 
-use util\Objects;
+use lang\partial\ValueObject;
+use lang\partial\WithCreation;
 
-class Book extends \lang\Object { use \util\objects\CreateWith;
+class Book extends \lang\Object {
+  use Book\including\ValueObject;
+  use Book\including\WithCreation;
+
   private $name, $author;
 
   /**
@@ -14,30 +18,5 @@ class Book extends \lang\Object { use \util\objects\CreateWith;
   public function __construct($name, Author $author= null) {
     $this->name= $name;
     $this->author= $author;
-  }
-
-  /** @return string */
-  public function name() { return $this->name; }
-
-  /** @return util.data.unittest.Author */
-  public function author() { return $this->author; }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return $this->getClassName().'@'.Objects::stringOf(get_object_vars($this));
-  }
-
-  /**
-   * Checks for equality
-   *
-   * @param  var $value
-   * @return bool
-   */
-  public function equals($value) {
-    return $value instanceof self && $this->name === $value->name && Objects::equal($this->author, $value->author);
   }
 }

--- a/src/test/php/util/address/unittest/Channel.class.php
+++ b/src/test/php/util/address/unittest/Channel.class.php
@@ -1,9 +1,13 @@
 <?php namespace util\address\unittest;
 
 use util\Date;
-use util\Objects;
+use lang\partial\ValueObject;
+use lang\partial\WithCreation;
 
-class Channel extends \lang\Object { use \util\objects\CreateWith;
+class Channel extends \lang\Object {
+  use Channel\including\ValueObject;
+  use Channel\including\WithCreation;
+
   private $title, $description, $pubDate, $generator, $link, $items;
 
   /**
@@ -23,49 +27,5 @@ class Channel extends \lang\Object { use \util\objects\CreateWith;
     $this->generator= $generator;
     $this->link= $link;
     $this->items= $items;
-  }
-
-  /** @return string */
-  public function title() { return $this->title; }
-
-  /** @return string */
-  public function description() { return $this->description; }
-
-  /** @return util.Date */
-  public function pubDate() { return $this->pubDate; }
-
-  /** @return string */
-  public function generator() { return $this->generator; }
-
-  /** @return string */
-  public function link() { return $this->link; }
-
-  /** @return util.data.unittest.Item[] */
-  public function items() { return $this->items; }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return $this->getClassName().'@'.Objects::stringOf(get_object_vars($this));
-  }
-
-  /**
-   * Checks for equality
-   *
-   * @param  var $value
-   * @return bool
-   */
-  public function equals($value) {
-    return $value instanceof self && (
-      $this->title === $value->title &&
-      $this->description === $value->description &&
-      $this->pubDate->equals($value->pubDate) &&
-      $this->generator === $value->generator &&
-      $this->link === $value->link &&
-      Objects::equal($this->items, $value->items)
-    );
   }
 }

--- a/src/test/php/util/address/unittest/Item.class.php
+++ b/src/test/php/util/address/unittest/Item.class.php
@@ -1,9 +1,13 @@
 <?php namespace util\address\unittest;
 
 use util\Date;
-use util\Objects;
+use lang\partial\ValueObject;
+use lang\partial\WithCreation;
 
-class Item extends \lang\Object { use \util\objects\CreateWith;
+class Item extends \lang\Object {
+  use Item\including\ValueObject;
+  use Item\including\WithCreation;
+
   private $title, $description, $pubDate, $link, $guid;
 
   /**

--- a/src/test/php/util/address/unittest/Item.class.php
+++ b/src/test/php/util/address/unittest/Item.class.php
@@ -26,44 +26,4 @@ class Item extends \lang\Object {
     $this->link= $link;
     $this->guid= $guid;
   }
-
-  /** @return string */
-  public function title() { return $this->title; }
-
-  /** @return string */
-  public function description() { return $this->description; }
-
-  /** @return util.Date */
-  public function pubDate() { return $this->pubDate; }
-
-  /** @return string */
-  public function link() { return $this->link; }
-
-  /** @return string */
-  public function guid() { return $this->guid; }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return $this->getClassName().'@'.Objects::stringOf(get_object_vars($this));
-  }
-
-  /**
-   * Checks for equality
-   *
-   * @param  var $value
-   * @return bool
-   */
-  public function equals($value) {
-    return $value instanceof self && (
-      $this->title === $value->title &&
-      $this->description === $value->description &&
-      $this->pubDate->equals($value->pubDate) &&
-      $this->link === $value->link &&
-      $this->guid === $value->guid
-    );
-  }
 }


### PR DESCRIPTION
This way we can remove [xp-forge/creation](https://github.com/xp-forge/creation) which serves only a very limited purpose.

* [x] Rewrite code
* [x] Decide when it's OK to drop PHP 5.4 and PHP 5.5 support ([xp-forge/partial](https://github.com/xp-forge/partial) requires PHP 5.6+)
* [x] Merge this PR
* [x] Delete https://packagist.org/packages/xp-forge/creation
* [x] Delete https://github.com/xp-forge/creation