### PR TITLE
Add util.address.RecordOf for record classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/reflection": "^1.0",
+    "xp-framework/reflection": "^1.9",
     "xp-framework/tokenize": "^9.0 | ^8.1",
     "php" : ">=7.0.0"
   },

--- a/src/main/php/util/address/RecordOf.class.php
+++ b/src/main/php/util/address/RecordOf.class.php
@@ -1,0 +1,61 @@
+<?php namespace util\address;
+
+use lang\Reflection;
+
+/**
+ * Creates a record based on a given type and addresses. Records
+ * are defined as having an all-arg constructor.
+ *
+ * @test  util.address.unittest.RecordOfTest
+ */
+class RecordOf implements Definition {
+  private $type, $addresses;
+
+  /**
+   * Creates a new object definition
+   *
+   * @param  lang.XPClass|string $type
+   * @param  [:function(util.address.Iteration): void] $addresses
+   */
+  public function __construct($type, $addresses) {
+    $this->type= Reflection::of($type);
+    $this->addresses= $addresses;
+  }
+
+  /**
+   * Address a given path. If nothing is defined, discard value silently.
+   *
+   * @param  [:var] $named
+   * @param  string $path
+   * @param  util.address.Iteration $iteration
+   * @return void
+   */
+  protected function next(&$named, $path, $iteration) {
+    if (isset($this->addresses[$path])) {
+      foreach ($this->addresses[$path]->__invoke($iteration) as $name => $value) {
+        $named[$name]= $value;
+      }
+    } else {
+      $iteration->next();
+    }
+  }
+
+  /**
+   * Creates a value from a given iteration
+   *
+   * @param  util.address.Iteration $iteration
+   * @return object
+   */
+  public function create($iteration) {
+    $named= [];
+    $base= $iteration->path().'/';
+    $length= strlen($base);
+
+    $this->next($named, '.', $iteration);
+    while (null !== ($path= $iteration->path()) && 0 === strncmp($path, $base, $length)) {
+      $this->next($named, substr($iteration->path(), $length), $iteration);
+    }
+
+    return $this->type->constructor()->newInstance($named);
+  }
+}

--- a/src/main/php/util/address/RecordOf.class.php
+++ b/src/main/php/util/address/RecordOf.class.php
@@ -31,10 +31,12 @@ class RecordOf implements Definition {
    * @return void
    */
   private function next(&$named, $path, $iteration) {
-    $address= $this->addresses[$path]
-      ?? $this->addresses['*']
-      ?? ('@' === $path[0] ? $this->addresses['@*'] ?? null : null)
-    ;
+    if ('@' === $path[0]) {
+      $address= $this->addresses[$path] ?? $this->addresses['@*'] ?? null;
+      $path= substr($path, 1);
+    } else {
+      $address= $this->addresses[$path] ?? $this->addresses['*'] ?? null;
+    }
 
     $address ? $address($named, $iteration, $path) : $iteration->next();
   }

--- a/src/main/php/util/address/RecordOf.class.php
+++ b/src/main/php/util/address/RecordOf.class.php
@@ -9,7 +9,7 @@ use lang\Reflection;
  * @test  util.address.unittest.RecordOfTest
  */
 class RecordOf implements Definition {
-  private $type, $addresses;
+  private $constructor, $addresses;
 
   /**
    * Creates a new object definition
@@ -18,7 +18,7 @@ class RecordOf implements Definition {
    * @param  [:function(util.address.Iteration): void] $addresses
    */
   public function __construct($type, $addresses) {
-    $this->type= Reflection::of($type);
+    $this->constructor= Reflection::of($type)->constructor();
     $this->addresses= $addresses;
   }
 
@@ -56,6 +56,6 @@ class RecordOf implements Definition {
       $this->next($named, substr($iteration->path(), $length), $iteration);
     }
 
-    return $this->type->constructor()->newInstance($named);
+    return $this->constructor->newInstance($named);
   }
 }

--- a/src/main/php/util/address/RecordOf.class.php
+++ b/src/main/php/util/address/RecordOf.class.php
@@ -32,7 +32,7 @@ class RecordOf implements Definition {
    */
   protected function next(&$named, $path, $iteration) {
     if (isset($this->addresses[$path])) {
-      foreach ($this->addresses[$path]->__invoke($iteration) as $name => $value) {
+      foreach ($this->addresses[$path]($iteration) as $name => $value) {
         $named[$name]= $value;
       }
     } else {

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -21,7 +21,7 @@ class RecordOfTest {
     Assert::equals(
       new Book('Name'),
       $address->next(new RecordOf($type, [
-        '.' => function($it) { return ['name' => $it->next()]; }
+        '.' => function(&$arguments, $it) { $arguments['name']= $it->next(); }
       ]))
     );
   }
@@ -32,7 +32,7 @@ class RecordOfTest {
     Assert::equals(
       new Book('Name'),
       $address->next(new RecordOf($type, [
-        'name'    => function($it) { return ['name' => $it->next()]; }
+        'name'    => function(&$arguments, $it) { $arguments['name']= $it->next(); }
       ]))
     );
   }
@@ -43,8 +43,8 @@ class RecordOfTest {
     Assert::equals(
       new Book('Name', new Author('Test')),
       $address->next(new RecordOf($type, [
-        'name'    => function($it) { return ['name' => $it->next()]; },
-        '@author' => function($it) { return ['author' => new Author($it->next())]; }
+        'name'    => function(&$arguments, $it) { $arguments['name']= $it->next(); },
+        '@author' => function(&$arguments, $it) { $arguments['author']= new Author($it->next()); }
       ]))
     );
   }

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -21,7 +21,7 @@ class RecordOfTest {
     Assert::equals(
       new Book('Name'),
       $address->next(new RecordOf($type, [
-        '.' => function($it) { yield 'name' => $it->next(); }
+        '.' => function($it) { return ['name' => $it->next()]; }
       ]))
     );
   }
@@ -32,7 +32,7 @@ class RecordOfTest {
     Assert::equals(
       new Book('Name'),
       $address->next(new RecordOf($type, [
-        'name'    => function($it) { yield 'name' => $it->next();}
+        'name'    => function($it) { return ['name' => $it->next()]; }
       ]))
     );
   }
@@ -43,8 +43,8 @@ class RecordOfTest {
     Assert::equals(
       new Book('Name', new Author('Test')),
       $address->next(new RecordOf($type, [
-        'name'    => function($it) { yield 'name' => $it->next(); },
-        '@author' => function($it) { yield 'author' => new Author($it->next()); }
+        'name'    => function($it) { return ['name' => $it->next()]; },
+        '@author' => function($it) { return ['author' => new Author($it->next())]; }
       ]))
     );
   }

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -1,0 +1,51 @@
+<?php namespace util\address\unittest;
+
+use lang\XPClass;
+use unittest\Assert;
+use unittest\{Test, Values};
+use util\address\{RecordOf, XmlString};
+
+class RecordOfTest {
+
+  /** @return var[][] */
+  protected function bookTypes() {
+    return [
+      ['util.address.unittest.Book'],
+      [XPClass::forName('util.address.unittest.Book')],
+    ];
+  }
+
+  #[Test, Values('bookTypes')]
+  public function compact_form($type) {
+    $address= new XmlString('<book>Name</book>');
+    Assert::equals(
+      new Book('Name'),
+      $address->next(new RecordOf($type, [
+        '.' => function($it) { yield 'name' => $it->next(); }
+      ]))
+    );
+  }
+
+  #[Test, Values('bookTypes')]
+  public function child_node($type) {
+    $address= new XmlString('<book><name>Name</name></book>');
+    Assert::equals(
+      new Book('Name'),
+      $address->next(new RecordOf($type, [
+        'name'    => function($it) { yield 'name' => $it->next();}
+      ]))
+    );
+  }
+
+  #[Test, Values('bookTypes')]
+  public function child_node_and_attributes($type) {
+    $address= new XmlString('<book author="Test"><name>Name</name></book>');
+    Assert::equals(
+      new Book('Name', new Author('Test')),
+      $address->next(new RecordOf($type, [
+        'name'    => function($it) { yield 'name' => $it->next(); },
+        '@author' => function($it) { yield 'author' => new Author($it->next()); }
+      ]))
+    );
+  }
+}

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -10,6 +10,7 @@ class RecordOfTest {
   /** @return var[][] */
   protected function bookTypes() {
     return [
+      [Book::class],
       ['util.address.unittest.Book'],
       [XPClass::forName('util.address.unittest.Book')],
     ];

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -48,4 +48,28 @@ class RecordOfTest {
       ]))
     );
   }
+
+  #[Test, Values('bookTypes')]
+  public function any_child($type) {
+    $address= new XmlString('<book><name>Name</name><author>Test</author></book>');
+    Assert::equals(
+      new Book('Name', new Author('Test')),
+      $address->next(new RecordOf($type, [
+        'author' => function(&$arguments, $it) { $arguments['author']= new Author($it->next()); },
+        '*'      => function(&$arguments, $it, $name) { $arguments[$name]= $it->next(); }
+      ]))
+    );
+  }
+
+  #[Test, Values('bookTypes')]
+  public function any_attribute($type) {
+    $address= new XmlString('<book name="Name"><author>Test</author></book>');
+    Assert::equals(
+      new Book('Name', new Author('Test')),
+      $address->next(new RecordOf($type, [
+        'author' => function(&$arguments, $it) { $arguments['author']= new Author($it->next()); },
+        '@*'     => function(&$arguments, $it, $name) { $arguments[$name]= $it->next(); }
+      ]))
+    );
+  }
 }

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -1,8 +1,7 @@
 <?php namespace util\address\unittest;
 
 use lang\XPClass;
-use unittest\Assert;
-use unittest\{Test, Values};
+use unittest\{Assert, Test, Values};
 use util\address\{RecordOf, XmlString};
 
 class RecordOfTest {


### PR DESCRIPTION
Records are defined as having an all-arg constructor. The `RecordOf` class expects a type and addresses:

* `.` - selects the node value itself
* `*` - selects any child node
* `[name]` - selects a child node with the given name
* `@*` - selects any attribute
* `@[name]` - selects an attribute with the given name

The functions modifies the given named arguments with the values provided by the iteration instance.

```php
class Person {
  public function __construct(private int $id, private string $name) { }

  public function id(): id { return $this->id; }
  public function name(): string { return $this->name; }
}

$stream= new XmlString('<person id="6100">Tim Taylor</person>');
$person= $stream->next(new RecordOf(Person::class, [
  '.'   => fn(&$args, $it) => $args['name']= $it->next(),
  '@id' => fn(&$args, $it) => $args['id']= $it->next(),
]));

// Person(id: '6100', name: 'Tim Taylor')
```

See also https://github.com/xp-lang/xp-records