### PR TITLE
Add util.address.MapOf to create maps

### DIFF
--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -1,0 +1,58 @@
+<?php namespace util\address;
+
+use lang\Reflection;
+
+/**
+ * Creates a map based on given addresses.
+ *
+ * @test  util.address.unittest.MapOfTest
+ */
+class MapOf implements Definition {
+  private $constructor, $addresses;
+
+  /**
+   * Creates a new map definition
+   *
+   * @param  [:function(util.address.Iteration): void] $addresses
+   */
+  public function __construct($addresses) {
+    $this->addresses= $addresses;
+  }
+
+  /**
+   * Address a given path. If nothing is defined, discard value silently.
+   *
+   * @param  [:var] $map
+   * @param  string $path
+   * @param  util.address.Iteration $iteration
+   * @return void
+   */
+  protected function next(&$map, $path, $iteration) {
+    if (isset($this->addresses[$path])) {
+      foreach ($this->addresses[$path]($iteration) as $name => $value) {
+        $map[$name]= $value;
+      }
+    } else {
+      $iteration->next();
+    }
+  }
+
+  /**
+   * Creates a value from a given iteration
+   *
+   * @param  util.address.Iteration $iteration
+   * @return object
+   */
+  public function create($iteration) {
+    $map= [];
+    $base= $iteration->path().'/';
+    $length= strlen($base);
+
+    $this->next($map, '.', $iteration);
+    while (null !== ($path= $iteration->path()) && 0 === strncmp($path, $base, $length)) {
+      $this->next($map, substr($iteration->path(), $length), $iteration);
+    }
+
+    return $map;
+  }
+}

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -28,10 +28,12 @@ class MapOf implements Definition {
    * @return void
    */
   private function next(&$result, $path, $iteration) {
-    $address= $this->addresses[$path]
-      ?? $this->addresses['*']
-      ?? ('@' === $path[0] ? $this->addresses['@*'] ?? null : null)
-    ;
+    if ('@' === $path[0]) {
+      $address= $this->addresses[$path] ?? $this->addresses['@*'] ?? null;
+      $path= substr($path, 1);
+    } else {
+      $address= $this->addresses[$path] ?? $this->addresses['*'] ?? null;
+    }
 
     $address ? $address($result, $iteration, $path) : $iteration->next();
   }

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -28,20 +28,19 @@ class MapOf implements Definition {
    * @return void
    */
   private function next(&$result, $path, $iteration) {
-    if ($address= $this->addresses[$path] ?? $this->addresses['*'] ?? null) {
-      $address($result, $iteration, $path);
-    } else if ('@' === $path[0] && $address= $this->addresses['@*'] ?? null) {
-      $address($result, $iteration, substr($path, 1));
-    } else {
-      $iteration->next();
-    }
+    $address= $this->addresses[$path]
+      ?? $this->addresses['*']
+      ?? ('@' === $path[0] ? $this->addresses['@*'] ?? null : null)
+    ;
+
+    $address ? $address($result, $iteration, $path) : $iteration->next();
   }
 
   /**
    * Creates a value from a given iteration
    *
    * @param  util.address.Iteration $iteration
-   * @return object
+   * @return [:var]
    */
   public function create($iteration) {
     $base= $iteration->path().'/';

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -8,7 +8,7 @@ use lang\Reflection;
  * @test  util.address.unittest.MapOfTest
  */
 class MapOf implements Definition {
-  private $constructor, $addresses;
+  private $addresses;
 
   /**
    * Creates a new map definition
@@ -28,8 +28,8 @@ class MapOf implements Definition {
    * @return void
    */
   protected function next(&$map, $path, $iteration) {
-    if (isset($this->addresses[$path])) {
-      foreach ($this->addresses[$path]($iteration) as $name => $value) {
+    if ($address= $this->addresses[$path] ?? ('.' === $path ? null : $this->addresses['*'] ?? null)) {
+      foreach ($address($iteration, $path) as $name => $value) {
         $map[$name]= $value;
       }
     } else {

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -22,19 +22,16 @@ class MapOf implements Definition {
   /**
    * Address a given path. If nothing is defined, discard value silently.
    *
-   * @param  [:var] $map
    * @param  string $path
    * @param  util.address.Iteration $iteration
-   * @return void
+   * @return [:var]
    */
-  protected function next(&$map, $path, $iteration) {
+  protected function next($path, $iteration) {
     if ($address= $this->addresses[$path] ?? ('.' === $path ? null : $this->addresses['*'] ?? null)) {
-      foreach ($address($iteration, $path) as $name => $value) {
-        $map[$name]= $value;
-      }
-    } else {
-      $iteration->next();
+      return $address($iteration, $path);
     }
+    $iteration->next();
+    return [];
   }
 
   /**
@@ -48,9 +45,9 @@ class MapOf implements Definition {
     $base= $iteration->path().'/';
     $length= strlen($base);
 
-    $this->next($map, '.', $iteration);
+    $map= $this->next('.', $iteration);
     while (null !== ($path= $iteration->path()) && 0 === strncmp($path, $base, $length)) {
-      $this->next($map, substr($iteration->path(), $length), $iteration);
+      $map+= $this->next(substr($iteration->path(), $length), $iteration);
     }
 
     return $map;

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -30,6 +30,7 @@ class MapOf implements Definition {
     if ($address= $this->addresses[$path] ?? ('.' === $path ? null : $this->addresses['*'] ?? null)) {
       return $address($iteration, $path);
     }
+
     $iteration->next();
     return [];
   }
@@ -41,7 +42,6 @@ class MapOf implements Definition {
    * @return object
    */
   public function create($iteration) {
-    $map= [];
     $base= $iteration->path().'/';
     $length= strlen($base);
 

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -27,8 +27,12 @@ class MapOf implements Definition {
    * @return [:var]
    */
   protected function next($path, $iteration) {
-    if ($address= $this->addresses[$path] ?? ('.' === $path ? null : $this->addresses['*'] ?? null)) {
+    if ($address= $this->addresses[$path] ?? null) {
       return $address($iteration, $path);
+    } else if ('.' !== $path[0] && $address= $this->addresses['*'] ?? null) {
+      return $address($iteration, $path);
+    } else if ('@' === $path[0] && $address= $this->addresses['@*'] ?? null) {
+      return $address($iteration, substr($path, 1));
     }
 
     $iteration->next();

--- a/src/main/php/util/address/MapOf.class.php
+++ b/src/main/php/util/address/MapOf.class.php
@@ -20,7 +20,8 @@ class MapOf implements Definition {
   }
 
   /**
-   * Address a given path. If nothing is defined, discard value silently.
+   * Address a given path. If nothing is defined, discard value silently and
+   * return an empty map.
    *
    * @param  string $path
    * @param  util.address.Iteration $iteration
@@ -47,11 +48,11 @@ class MapOf implements Definition {
    */
   public function create($iteration) {
     $base= $iteration->path().'/';
-    $length= strlen($base);
+    $offset= strlen($base);
 
     $map= $this->next('.', $iteration);
-    while (null !== ($path= $iteration->path()) && 0 === strncmp($path, $base, $length)) {
-      $map+= $this->next(substr($iteration->path(), $length), $iteration);
+    while (null !== ($path= $iteration->path()) && 0 === strncmp($path, $base, $offset)) {
+      $map+= $this->next(substr($iteration->path(), $offset), $iteration);
     }
 
     return $map;

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -189,7 +189,7 @@ class XmlIterator implements Iterator {
     }
 
     $pair= array_shift($this->pairs);
-    // echo "<<< ", $pair ? $pair->toString() : "(null)", "\n";
+    // echo "<<< ", $pair ? "Pair<{$pair->key}= {$pair->value}>" : "(null)", "\n";
     return $pair;
   }
 

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -40,12 +40,24 @@ class MapOfTest {
   }
 
   #[Test]
-  public function star() {
+  public function any_child() {
     $address= new XmlString('<book><name>Name</name><author>Test</author></book>');
     Assert::equals(
       ['name' => 'Name', 'author' => 'Test'],
       $address->next(new MapOf([
         '*' => function($it, $node) { return [$node => $it->next()]; }
+      ]))
+    );
+  }
+
+  #[Test]
+  public function any_attribute() {
+    $address= new XmlString('<book asin="B01N1UPZ10" author="Test">Name</book>');
+    Assert::equals(
+      ['name' => 'Name', 'asin' => 'B01N1UPZ10', 'author' => 'Test'],
+      $address->next(new MapOf([
+        '@*' => function($it, $node) { return [$node => $it->next()]; },
+        '.'  => function($it) { return ['name' => $it->next()]; }
       ]))
     );
   }

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -54,7 +54,7 @@ class MapOfTest {
   public function any_attribute() {
     $address= new XmlString('<book asin="B01N1UPZ10" author="Test">Name</book>');
     Assert::equals(
-      ['name' => 'Name', 'asin' => 'B01N1UPZ10', 'author' => 'Test'],
+      ['name' => 'Name', '@asin' => 'B01N1UPZ10', '@author' => 'Test'],
       $address->next(new MapOf([
         '@*' => function(&$self, $it, $attr) { $self[$attr]= $it->next(); },
         '.'  => function(&$self, $it) { $self['name']= $it->next(); }

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -38,4 +38,15 @@ class MapOfTest {
       ]))
     );
   }
+
+  #[Test]
+  public function star() {
+    $address= new XmlString('<book><name>Name</name><author>Test</author></book>');
+    Assert::equals(
+      ['name' => 'Name', 'author' => 'Test'],
+      $address->next(new MapOf([
+        '*' => function($it, $node) { return [$node => $it->next()]; }
+      ]))
+    );
+  }
 }

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -56,7 +56,7 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name', 'asin' => 'B01N1UPZ10', 'author' => 'Test'],
       $address->next(new MapOf([
-        '@*' => function($it, $node) { return [$node => $it->next()]; },
+        '@*' => function($it, $attr) { return [$attr => $it->next()]; },
         '.'  => function($it) { return ['name' => $it->next()]; }
       ]))
     );

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -11,7 +11,7 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name'],
       $address->next(new MapOf([
-        '.' => function($it) { return ['name' => $it->next()]; }
+        '.' => function(&$self, $it) { $self['name']= $it->next(); }
       ]))
     );
   }
@@ -22,7 +22,7 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name'],
       $address->next(new MapOf([
-        'name'    => function($it) { return ['name' => $it->next()]; }
+        'name'    => function(&$self, $it) { $self['name']= $it->next(); }
       ]))
     );
   }
@@ -33,8 +33,8 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name', 'author' => 'Test'],
       $address->next(new MapOf([
-        '@author' => function($it) { return ['author' => $it->next()]; },
-        'name'    => function($it) { return ['name' => $it->next()]; }
+        '@author' => function(&$self, $it) { $self['author']= $it->next(); },
+        'name'    => function(&$self, $it) { $self['name']= $it->next(); }
       ]))
     );
   }
@@ -45,7 +45,7 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name', 'author' => 'Test'],
       $address->next(new MapOf([
-        '*' => function($it, $node) { return [$node => $it->next()]; }
+        '*' => function(&$self, $it, $node) { $self[$node]= $it->next(); }
       ]))
     );
   }
@@ -56,8 +56,8 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name', 'asin' => 'B01N1UPZ10', 'author' => 'Test'],
       $address->next(new MapOf([
-        '@*' => function($it, $attr) { return [$attr => $it->next()]; },
-        '.'  => function($it) { return ['name' => $it->next()]; }
+        '@*' => function(&$self, $it, $attr) { $self[$attr]= $it->next(); },
+        '.'  => function(&$self, $it) { $self['name']= $it->next(); }
       ]))
     );
   }

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -1,0 +1,41 @@
+<?php namespace util\address\unittest;
+
+use unittest\{Assert, Test};
+use util\address\{MapOf, XmlString};
+
+class MapOfTest {
+
+  #[Test]
+  public function compact_form() {
+    $address= new XmlString('<book>Name</book>');
+    Assert::equals(
+      ['name' => 'Name'],
+      $address->next(new MapOf([
+        '.' => function($it) { return ['name' => $it->next()]; }
+      ]))
+    );
+  }
+
+  #[Test]
+  public function child_node() {
+    $address= new XmlString('<book><name>Name</name></book>');
+    Assert::equals(
+      ['name' => 'Name'],
+      $address->next(new MapOf([
+        'name'    => function($it) { return ['name' => $it->next()]; }
+      ]))
+    );
+  }
+
+  #[Test]
+  public function child_node_and_attributes() {
+    $address= new XmlString('<book author="Test"><name>Name</name></book>');
+    Assert::equals(
+      ['name' => 'Name', 'author' => 'Test'],
+      $address->next(new MapOf([
+        '@author' => function($it) { return ['author' => $it->next()]; },
+        'name'    => function($it) { return ['name' => $it->next()]; }
+      ]))
+    );
+  }
+}

--- a/src/test/php/util/address/unittest/MapOfTest.class.php
+++ b/src/test/php/util/address/unittest/MapOfTest.class.php
@@ -45,7 +45,7 @@ class MapOfTest {
     Assert::equals(
       ['name' => 'Name', 'author' => 'Test'],
       $address->next(new MapOf([
-        '*' => function(&$self, $it, $node) { $self[$node]= $it->next(); }
+        '*' => function(&$self, $it, $name) { $self[$name]= $it->next(); }
       ]))
     );
   }
@@ -54,9 +54,9 @@ class MapOfTest {
   public function any_attribute() {
     $address= new XmlString('<book asin="B01N1UPZ10" author="Test">Name</book>');
     Assert::equals(
-      ['name' => 'Name', '@asin' => 'B01N1UPZ10', '@author' => 'Test'],
+      ['name' => 'Name', 'asin' => 'B01N1UPZ10', 'author' => 'Test'],
       $address->next(new MapOf([
-        '@*' => function(&$self, $it, $attr) { $self[$attr]= $it->next(); },
+        '@*' => function(&$self, $it, $name) { $self[$name]= $it->next(); },
         '.'  => function(&$self, $it) { $self['name']= $it->next(); }
       ]))
     );


### PR DESCRIPTION
The `MapOf` class expects addresses:

* `.` - selects the node value itself
* `*` - selects any child node
* `[name]` - selects a child node with the given name
* `@*` - selects any attribute
* `@[name]` - selects an attribute with the given name

The functions yield keys and their respective values.

## Example 1

Transforms a node with an attribute and content to a map.

```php
$stream= new XmlString('<person id="6100">Tim Taylor</person>');
$person= $stream->next(new MapOf([
  '@id' => fn(&$self, $it) => $self['id']= $it->next(),
  '.'   => fn(&$self, $it) => $self['name']= $it->next(),
]));

// ['id' => '6100', 'name' => 'Tim Taylor']
```

## Example 2

Transforms a node with an attribute and a child node to a map.

```php
$stream= new XmlString('<person id="6100"><name>Tim Taylor</name></person>');
$person= $stream->next(new MapOf([
  '@id'  => fn(&$self, $it) => $self['id']= $it->next(),
  'name' => fn(&$self, $it) => $self['name']= $it->next(),
]));

// ['id' => '6100', 'name' => 'Tim Taylor']
```

## Example 3

Transform child nodes and their contents to map key/value pairs.

```php
$stream= new XmlString('<person><id>6100</id><name>Tim Taylor</name></person>');
$person= $stream->next(new MapOf([
  '*' => fn(&$self, $it, $node) => $self[$node]= $it->next(),
]));

// ['id' => '6100', 'name' => 'Tim Taylor']
```