### PR TITLE
Refactor ObjectOf to accept function(object, util.address.Iteration): void

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ $socket= /* ... */
 
 $address= new XmlStream($socket->in());
 $book= $address->next(new ObjectOf(Book::class, [
-  'name'   => function($it) { $this->name= $it->next(); },
-  'author' => function($it) { $this->author= $it->next(new ObjectOf(Author::class, [
-    'name'   => function($it) { $this->name= $it->next() ?: '(unknown author)'; }
+  'name'   => function($self, $it) { $self->name= $it->next(); },
+  'author' => function($self, $it) { $self->author= $it->next(new ObjectOf(Author::class, [
+    'name'   => function($self, $it) { $self->name= $it->next() ?: '(unknown author)'; }
   ])); }
 ]);
 ```
@@ -76,12 +76,12 @@ Sequence::of($stream)
   ->filter(function($value, $path) { return '//channel/item' === $path; })
   ->map(function() use($stream) {
     return $stream->next(new ObjectOf(Item::class, [
-      'title'       => function($it) { $this->title= $it->next(); },
-      'description' => function($it) { $this->description= $it->next(); },
-      'pubDate'     => function($it) { $this->pubDate= new Date($it->next()); },
-      'generator'   => function($it) { $this->generator= $it->next(); },
-      'link'        => function($it) { $this->link= $it->next(); },
-      'guid'        => function($it) { $this->guid= $it->next(); }
+      'title'       => function($self, $it) { $self->title= $it->next(); },
+      'description' => function($self, $it) { $self->description= $it->next(); },
+      'pubDate'     => function($self, $it) { $self->pubDate= new Date($it->next()); },
+      'generator'   => function($self, $it) { $self->generator= $it->next(); },
+      'link'        => function($self, $it) { $self->link= $it->next(); },
+      'guid'        => function($self, $it) { $self->guid= $it->next(); }
     ]));
   })
   ->each(function($item) {

--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ Any `Address` instance can be iterated using the `foreach` statement. Using the 
 
 ```php
 use peer\http\HttpConnection;
+use util\data\Sequence;
+use util\Date;
 use util\address\{XmlStream, ObjectOf};
+use util\cmd\Console;
 
-$conn= new HttpConnection('http://www.tagesschau.de/xml/rss2');
+$conn= new HttpConnection('https://www.tagesschau.de/xml/rss2/');
 $stream= new XmlStream($conn->get()->in());
 
 Sequence::of($stream)

--- a/README.md
+++ b/README.md
@@ -76,20 +76,15 @@ $conn= new HttpConnection('https://www.tagesschau.de/xml/rss2/');
 $stream= new XmlStream($conn->get()->in());
 
 Sequence::of($stream)
-  ->filter(function($value, $path) { return '//channel/item' === $path; })
-  ->map(function() use($stream) {
-    return $stream->next(new ObjectOf(Item::class, [
-      'title'       => function($self, $it) { $self->title= $it->next(); },
-      'description' => function($self, $it) { $self->description= $it->next(); },
-      'pubDate'     => function($self, $it) { $self->pubDate= new Date($it->next()); },
-      'generator'   => function($self, $it) { $self->generator= $it->next(); },
-      'link'        => function($self, $it) { $self->link= $it->next(); },
-      'guid'        => function($self, $it) { $self->guid= $it->next(); }
-    ]));
-  })
-  ->each(function($item) {
-    Console::writeLine('- ', $item->title());
-    Console::writeLine('  ', $item->link());
-  })
+  ->filter(fn($value, $path) => '//channel/item' === $path)
+  ->map(fn() => $stream->next(new ObjectOf(Item::class, [
+    'title'       => fn($self, $it) => $self->title= $it->next(),
+    'description' => fn($self, $it) => $self->description= $it->next(),
+    'pubDate'     => fn($self, $it) => $self->pubDate= new Date($it->next()),
+    'generator'   => fn($self, $it) => $self->generator= $it->next(),
+    'link'        => fn($self, $it) => $self->link= $it->next(),
+    'guid'        => fn($self, $it) => $self->guid= $it->next(),
+  ])))
+  ->each(fn($item) => Console::writeLine('- ', $item->title, "\n  ", $item->link))
 ;
 ```

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -189,7 +189,7 @@ class XmlIterator implements Iterator {
     }
 
     $pair= array_shift($this->pairs);
-    // echo "<<< ", $pair ? $pair->toString() : "(null)", "\n";
+    // echo "<<< ", $pair ? "Pair<{$pair->key}= {$pair->value}>" : "(null)", "\n";
     return $pair;
   }
 

--- a/src/test/php/util/address/unittest/ArrayOfTest.class.php
+++ b/src/test/php/util/address/unittest/ArrayOfTest.class.php
@@ -29,7 +29,7 @@ class ArrayOfTest {
     Assert::equals(
       [new Book('Book #1'), new Book('Book #2')],
       $address->next(new Enclosing('/'))->next(new ArrayOf(new ObjectOf(Book::class, [
-        '.' => function($iteration) { $this->name= $iteration->next(); }
+        '.' => function($self, $it) { $self->name= $it->next(); }
       ])))
     );
   }
@@ -40,8 +40,8 @@ class ArrayOfTest {
     Assert::equals(
       [new Book('Book #1', new Author('Test')), new Book('Book #2')],
       $address->next(new Enclosing('/'))->next(new ArrayOf(new ObjectOf(Book::class, [
-        '.'       => function($iteration) { $this->name= $iteration->next(); },
-        '@author' => function($iteration) { $this->author= new Author($iteration->next()); }
+        '.'       => function($self, $it) { $self->name= $it->next(); },
+        '@author' => function($self, $it) { $self->author= new Author($it->next()); }
       ])))
     );
   }

--- a/src/test/php/util/address/unittest/BookDefinition.class.php
+++ b/src/test/php/util/address/unittest/BookDefinition.class.php
@@ -6,9 +6,9 @@ class BookDefinition extends ObjectOf {
 
   public function __construct() {
     parent::__construct(Book::class, [
-      'name'   => function($iteration) { $this->name= $iteration->next(); },
-      'author' => function($iteration) { $this->author= $iteration->next(new ObjectOf(Author::class, [
-        'name'   => function($iteration) { $this->name= $iteration->next() ?: 'Test'; }
+      'name'   => function($self, $it) { $self->name= $it->next(); },
+      'author' => function($self, $it) { $self->author= $it->next(new ObjectOf(Author::class, [
+        'name'   => function($self, $it) { $self->name= $it->next() ?: 'Test'; }
       ])); }
     ]);
   }

--- a/src/test/php/util/address/unittest/ObjectOfTest.class.php
+++ b/src/test/php/util/address/unittest/ObjectOfTest.class.php
@@ -21,7 +21,7 @@ class ObjectOfTest {
     Assert::equals(
       new Book('Name'),
       $address->next(new ObjectOf($type, [
-        '.' => function($it) { $this->name= $it->next(); }
+        '.' => function($self, $it) { $self->name= $it->next(); }
       ]))
     );
   }
@@ -32,7 +32,7 @@ class ObjectOfTest {
     Assert::equals(
       new Book('Name'),
       $address->next(new ObjectOf($type, [
-        'name'    => function($it) { $this->name= $it->next(); }
+        'name'    => function($self, $it) { $self->name= $it->next(); }
       ]))
     );
   }
@@ -43,8 +43,8 @@ class ObjectOfTest {
     Assert::equals(
       new Book('Name', new Author('Test')),
       $address->next(new ObjectOf($type, [
-        'name'    => function($it) { $this->name= $it->next(); },
-        '@author' => function($it) { $this->author= new Author($it->next()); }
+        'name'    => function($self, $it) { $self->name= $it->next(); },
+        '@author' => function($self, $it) { $self->author= new Author($it->next()); }
       ]))
     );
   }
@@ -53,5 +53,14 @@ class ObjectOfTest {
   public function child_node_ordering($xml) {
     $address= new XmlString($xml);
     Assert::equals(new Book('Name', new Author('Test')), $address->next(new BookDefinition()));
+  }
+
+  #[Test, Values('bookTypes')]
+  public function deprecated_form($type) {
+    $definition= new ObjectOf($type, ['.' => function($it) { $this->name= $it->next(); }]);
+    \xp::gc();
+
+    $address= new XmlString('<book>Name</book>');
+    Assert::equals(new Book('Name'), $address->next($definition));
   }
 }

--- a/src/test/php/util/address/unittest/ObjectOfTest.class.php
+++ b/src/test/php/util/address/unittest/ObjectOfTest.class.php
@@ -49,6 +49,30 @@ class ObjectOfTest {
     );
   }
 
+  #[Test, Values('bookTypes')]
+  public function any_child($type) {
+    $address= new XmlString('<book author="Test"><name>Name</name></book>');
+    Assert::equals(
+      new Book('Name', new Author('Test')),
+      $address->next(new ObjectOf($type, [
+        '@author' => function($self, $it) { $self->author= new Author($it->next()); },
+        '*'       => function($self, $it, $name) { $self->$name= $it->next(); }
+      ]))
+    );
+  }
+
+  #[Test, Values('bookTypes')]
+  public function any_attribute($type) {
+    $address= new XmlString('<book author="Test"><name>Name</name></book>');
+    Assert::equals(
+      new Book('Name', new Author('Test')),
+      $address->next(new ObjectOf($type, [
+        '@*'   => function($self, $it, $name) { $self->{$name}= new Author($it->next()); },
+        'name' => function($self, $it) { $self->name= $it->next(); }
+      ]))
+    );
+  }
+
   #[Test, Values(['<book><name>Name</name><author><name/></author></book>', '<book><author><name/></author><name>Name</name></book>', '<book><name>Name</name><author><name>Test</name></author></book>', '<book><author><name>Test</name></author><name>Name</name></book>'])]
   public function child_node_ordering($xml) {
     $address= new XmlString($xml);

--- a/src/test/php/util/address/unittest/XmlInputTest.class.php
+++ b/src/test/php/util/address/unittest/XmlInputTest.class.php
@@ -21,18 +21,18 @@ class XmlInputTest {
   #[Test, Values('inputs')]
   public function feed($input) {
     $feed= $input->next(new ObjectOf(Channel::class, [
-      'channel/title'       => function($iteration) { $this->title= $iteration->next(); },
-      'channel/description' => function($iteration) { $this->description= $iteration->next(); },
-      'channel/pubDate'     => function($iteration) { $this->pubDate= new Date($iteration->next()); },
-      'channel/generator'   => function($iteration) { $this->generator= $iteration->next(); },
-      'channel/link'        => function($iteration) { $this->link= $iteration->next(); },
-      'channel/item'        => function($iteration) { $this->items[]= $iteration->next(new ObjectOf(Item::class, [
-        'title'               => function($iteration) { $this->title= $iteration->next(); },
-        'description'         => function($iteration) { $this->description= $iteration->next(); },
-        'pubDate'             => function($iteration) { $this->pubDate= new Date($iteration->next()); },
-        'generator'           => function($iteration) { $this->generator= $iteration->next(); },
-        'link'                => function($iteration) { $this->link= $iteration->next(); },
-        'guid'                => function($iteration) { $this->guid= $iteration->next(); }
+      'channel/title'       => function($self, $it) { $self->title= $it->next(); },
+      'channel/description' => function($self, $it) { $self->description= $it->next(); },
+      'channel/pubDate'     => function($self, $it) { $self->pubDate= new Date($it->next()); },
+      'channel/generator'   => function($self, $it) { $self->generator= $it->next(); },
+      'channel/link'        => function($self, $it) { $self->link= $it->next(); },
+      'channel/item'        => function($self, $it) { $self->items[]= $it->next(new ObjectOf(Item::class, [
+        'title'               => function($self, $it) { $self->title= $it->next(); },
+        'description'         => function($self, $it) { $self->description= $it->next(); },
+        'pubDate'             => function($self, $it) { $self->pubDate= new Date($it->next()); },
+        'generator'           => function($self, $it) { $self->generator= $it->next(); },
+        'link'                => function($self, $it) { $self->link= $it->next(); },
+        'guid'                => function($self, $it) { $self->guid= $it->next(); }
       ])); }
     ]));
 


### PR DESCRIPTION
Brings the API in line with PRs #7 and #8 while retaining BC

```php
$address= new XmlString('<book author="Test"><name>Name</name></book>');

// Old usage, continues to work but raises a deprecation warning
$book= $address->next(new ObjectOf($type, [
  'name'    => function($it) { $this->name= $it->next(); },
  '@author' => function($it) { $this->author= new Author($it->next()); }
]));

// New usage
$book= $address->next(new ObjectOf($type, [
  'name'    => function($self, $it) { $self->name= $it->next(); },
  '@author' => function($self, $it) { $self->author= new Author($it->next()); }
]));
```