### PR TITLE
Introduce Address::value() to return current value...

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ use util\Date;
 use util\address\{XmlStream, ObjectOf};
 use util\cmd\Console;
 
+class Item {
+  public $title, $description, $pubDate, $generator, $link, $guid;
+}
+
 $conn= new HttpConnection('https://www.tagesschau.de/xml/rss2/');
 $stream= new XmlStream($conn->get()->in());
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ class Item {
   public $title, $description, $pubDate, $generator, $link, $guid;
 }
 
-$item= new ObjectOf(Item::class, [
+$definition= new ObjectOf(Item::class, [
   'title'       => fn($self, $it) => $self->title= $it->next(),
   'description' => fn($self, $it) => $self->description= $it->next(),
   'pubDate'     => fn($self, $it) => $self->pubDate= new Date($it->next()),
@@ -159,15 +159,6 @@ $item= new ObjectOf(Item::class, [
 
 $conn= new HttpConnection('https://www.tagesschau.de/xml/rss2/');
 $stream= new XmlStream($conn->get()->in());
-
-$definition= new ObjectOf(Item::class, [
-  'title'       => fn($self, $it) => $self->title= $it->next(),
-  'description' => fn($self, $it) => $self->description= $it->next(),
-  'pubDate'     => fn($self, $it) => $self->pubDate= new Date($it->next()),
-  'generator'   => fn($self, $it) => $self->generator= $it->next(),
-  'link'        => fn($self, $it) => $self->link= $it->next(),
-  'guid'        => fn($self, $it) => $self->guid= $it->next(),
-]);
 
 Sequence::of($stream)
   ->filter(fn($value, $path) => '//channel/item' === $path)

--- a/README.md
+++ b/README.md
@@ -148,19 +148,21 @@ class Item {
   public $title, $description, $pubDate, $generator, $link, $guid;
 }
 
+$item= new ObjectOf(Item::class, [
+  'title'       => fn($self, $it) => $self->title= $it->next(),
+  'description' => fn($self, $it) => $self->description= $it->next(),
+  'pubDate'     => fn($self, $it) => $self->pubDate= new Date($it->next()),
+  'generator'   => fn($self, $it) => $self->generator= $it->next(),
+  'link'        => fn($self, $it) => $self->link= $it->next(),
+  'guid'        => fn($self, $it) => $self->guid= $it->next(),
+]);
+
 $conn= new HttpConnection('https://www.tagesschau.de/xml/rss2/');
 $stream= new XmlStream($conn->get()->in());
 
 Sequence::of($stream)
   ->filter(fn($value, $path) => '//channel/item' === $path)
-  ->map(fn() => $stream->value(new ObjectOf(Item::class, [
-    'title'       => fn($self, $it) => $self->title= $it->next(),
-    'description' => fn($self, $it) => $self->description= $it->next(),
-    'pubDate'     => fn($self, $it) => $self->pubDate= new Date($it->next()),
-    'generator'   => fn($self, $it) => $self->generator= $it->next(),
-    'link'        => fn($self, $it) => $self->link= $it->next(),
-    'guid'        => fn($self, $it) => $self->guid= $it->next(),
-  ])))
+  ->map(fn() => $stream->value($item))
   ->each(fn($item) => Console::writeLine('- ', $item->title, "\n  ", $item->link))
 ;
 ```

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -60,10 +60,13 @@ abstract class Address implements IteratorAggregate {
    * @param  util.address.Definition $definition
    * @param  string $base
    * @return var
+   * @throws util.NoSuchElementException if there are no more eements
    */
   public function value(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
-    return $it->valid() ? $it->value($definition, $base) : null;
+    if ($it->valid()) return $it->value($definition, $base);
+
+    throw new NoSuchElementException('No more elements in iterator');    
   }
 
   /**
@@ -80,8 +83,8 @@ abstract class Address implements IteratorAggregate {
       $value= $it->value($definition, $base);
       $it->next();
       return $value;
-    } else {
-      throw new NoSuchElementException('No more elements in iterator');
     }
+
+    throw new NoSuchElementException('No more elements in iterator');
   }
 }

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -60,7 +60,7 @@ abstract class Address implements IteratorAggregate {
    * @param  util.address.Definition $definition
    * @param  string $base
    * @return var
-   * @throws util.NoSuchElementException if there are no more eements
+   * @throws util.NoSuchElementException if there are no more elements
    */
   public function value(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
@@ -77,7 +77,7 @@ abstract class Address implements IteratorAggregate {
    * @param  util.address.Definition $definition
    * @param  string $base
    * @return var
-   * @throws util.NoSuchElementException if there are no more eements
+   * @throws util.NoSuchElementException if there are no more elements
    */
   public function next(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -81,7 +81,6 @@ abstract class Address implements IteratorAggregate {
    * @throws util.NoSuchElementException if there are no more eements
    */
   public function next(Definition $definition= null, $base= '/') {
-    $this->value= null;
     if ($definition) {
       return $definition->create(new Iteration($this, $base));
     } else {

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -65,7 +65,7 @@ abstract class Address implements IteratorAggregate {
   public function value(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
     if ($it->valid()) {
-      return null === $definition ? $it->current() : $it->value($definition, $this, $base);
+      return null === $definition ? $it->current() : $it->value($definition, $this, $base, true);
     }
 
     throw new NoSuchElementException('No more elements in iterator');    
@@ -82,7 +82,7 @@ abstract class Address implements IteratorAggregate {
   public function next(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
     if ($it->valid()) {
-      $value= null === $definition ? $it->current() : $it->value($definition, $this, $base);
+      $value= null === $definition ? $it->current() : $it->value($definition, $this, $base, false);
       $it->next();
       return $value;
     }

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -63,13 +63,7 @@ abstract class Address implements IteratorAggregate {
    */
   public function value(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
-    if (null === $definition) return $it->current();
-
-    // Fetch next value, which will typically forward the cursor over all
-    // child nodes, then back up exactly one iteration step.
-    $value= $definition->create(new Iteration($this, $base));
-    $it->backup();
-    return $value;
+    return $it->valid() ? $it->value($definition, $base) : null;
   }
 
   /**
@@ -81,17 +75,13 @@ abstract class Address implements IteratorAggregate {
    * @throws util.NoSuchElementException if there are no more eements
    */
   public function next(Definition $definition= null, $base= '/') {
-    if ($definition) {
-      return $definition->create(new Iteration($this, $base));
+    $it= $this->getIterator(true);
+    if ($it->valid()) {
+      $value= $it->value($definition, $base);
+      $it->next();
+      return $value;
     } else {
-      $it= $this->getIterator(true);
-      if ($it->valid()) {
-        $value= $it->current();
-        $it->next();
-        return $value;
-      } else {
-        throw new NoSuchElementException('No more elements in iterator');
-      }
+      throw new NoSuchElementException('No more elements in iterator');
     }
   }
 }

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -64,7 +64,9 @@ abstract class Address implements IteratorAggregate {
    */
   public function value(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
-    if ($it->valid()) return $it->value($definition, $base);
+    if ($it->valid()) {
+      return null === $definition ? $it->current() : $it->value($definition, $this, $base);
+    }
 
     throw new NoSuchElementException('No more elements in iterator');    
   }
@@ -80,7 +82,7 @@ abstract class Address implements IteratorAggregate {
   public function next(Definition $definition= null, $base= '/') {
     $it= $this->getIterator(true);
     if ($it->valid()) {
-      $value= $it->value($definition, $base);
+      $value= null === $definition ? $it->current() : $it->value($definition, $this, $base);
       $it->next();
       return $value;
     }

--- a/src/main/php/util/address/Enclosing.class.php
+++ b/src/main/php/util/address/Enclosing.class.php
@@ -27,6 +27,6 @@ class Enclosing implements Definition {
     }
 
     $iteration->next();
-    return $iteration->input();
+    return $iteration;
   }
 }

--- a/src/main/php/util/address/Enclosing.class.php
+++ b/src/main/php/util/address/Enclosing.class.php
@@ -27,6 +27,6 @@ class Enclosing implements Definition {
     }
 
     $iteration->next();
-    return $iteration;
+    return $iteration->input();
   }
 }

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -6,15 +6,15 @@ class Iteration {
   /**
    * Creates an iteration
    *
-   * @param  util.address.Address $input
+   * @param  util.address.XmlIterator $input
    * @param  string $base
    */
-  public function __construct(Address $input, $base) {
+  public function __construct(XmlIterator $input, $base) {
     $this->input= $input;
-    $this->base= $base.'/';
+    $this->base= $base;
   }
 
-  /** @return util.address.Address */
+  /** @return util.address.XmlIterator */
   public function input() { return $this->input; }
 
   /** @return string */
@@ -24,16 +24,19 @@ class Iteration {
   public function valid() { return $this->input->valid(); }
 
   /** @return string */
-  public function path() { return $this->input->path(); }
+  public function path() { return $this->input->valid() ? $this->input->key() : null; }
 
   /**
    * Returns the next value according to the given definition
    *
    * @param  util.address.Definition $definition
    * @return var
-   * @throws util.NoSuchElementException if there are no more eements
    */
   public function next(Definition $definition= null) {
-    return $this->input->next($definition, $this->path());
+    try {
+      return $this->input->value($definition, $this->base.'/');
+    } finally {
+      $this->input->next();
+    }
   }
 }

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -2,6 +2,7 @@
 
 class Iteration {
   private $input, $base;
+  public $tokens= [];
 
   /**
    * Creates an iteration
@@ -27,13 +28,17 @@ class Iteration {
   public function path() { return $this->input->path(); }
 
   /**
-   * Returns the next value according to the given definition
+   * Returns the next value according to the given definition.
    *
    * @param  util.address.Definition $definition
    * @return var
-   * @throws util.NoSuchElementException if there are no more elements
    */
   public function next(Definition $definition= null) {
-    return $this->input->next($definition, $this->input->path());
+    $it= $this->input->getIterator(true);
+    $this->tokens[]= $it->token;
+
+    $value= null === $definition ? $it->current() : $it->value($definition, $this->input, $this->base);
+    $it->next();
+    return $value;
   }
 }

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -31,6 +31,7 @@ class Iteration {
    *
    * @param  util.address.Definition $definition
    * @return var
+   * @throws util.NoSuchElementException if there are no more elements
    */
   public function next(Definition $definition= null) {
     return $this->input->next($definition, $this->input->path());

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -6,15 +6,15 @@ class Iteration {
   /**
    * Creates an iteration
    *
-   * @param  util.address.XmlIterator $input
+   * @param  util.address.Address $input
    * @param  string $base
    */
-  public function __construct(XmlIterator $input, $base) {
+  public function __construct(Address $input, $base) {
     $this->input= $input;
-    $this->base= $base;
+    $this->base= $base.'/';
   }
 
-  /** @return util.address.XmlIterator */
+  /** @return util.address.Address */
   public function input() { return $this->input; }
 
   /** @return string */
@@ -24,7 +24,7 @@ class Iteration {
   public function valid() { return $this->input->valid(); }
 
   /** @return string */
-  public function path() { return $this->input->valid() ? $this->input->key() : null; }
+  public function path() { return $this->input->path(); }
 
   /**
    * Returns the next value according to the given definition
@@ -33,10 +33,6 @@ class Iteration {
    * @return var
    */
   public function next(Definition $definition= null) {
-    try {
-      return $this->input->value($definition, $this->base.'/');
-    } finally {
-      $this->input->next();
-    }
+    return $this->input->next($definition, $this->input->path());
   }
 }

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -37,7 +37,7 @@ class Iteration {
     $it= $this->input->getIterator(true);
     $this->tokens[]= $it->token;
 
-    $value= null === $definition ? $it->current() : $it->value($definition, $this->input, $this->base);
+    $value= null === $definition ? $it->current() : $it->value($definition, $this->input, $this->base, false);
     $it->next();
     return $value;
   }

--- a/src/main/php/util/address/Pair.class.php
+++ b/src/main/php/util/address/Pair.class.php
@@ -1,16 +1,18 @@
 <?php namespace util\address;
 
 class Pair {
-  public $key, $value;
+  public $path, $content, $value;
 
   /**
    * Creates a new pair
    *
-   * @param  var $key
-   * @param  var $value
+   * @param  var $path
+   * @param  var $content
+   * @param  ?array<var> $value
    */
-  public function __construct($key, $value) {
-    $this->key= $key;
+  public function __construct($path, $content, $value= null) {
+    $this->path= $path;
+    $this->content= $content;
     $this->value= $value;
   }
 }

--- a/src/main/php/util/address/Token.class.php
+++ b/src/main/php/util/address/Token.class.php
@@ -1,18 +1,28 @@
 <?php namespace util\address;
 
 class Token {
-  public $path, $content, $value;
+  public $path, $content;
+  public $source= null;
 
   /**
    * Creates a new token
    *
    * @param  string $path
    * @param  var $content
-   * @param  ?array<var> $value
    */
-  public function __construct($path, $content, $value= null) {
+  public function __construct($path, $content) {
     $this->path= $path;
     $this->content= $content;
-    $this->value= $value;
+  }
+
+  /**
+   * Sets source
+   *
+   * @param  util.address.Token[] $source
+   * @return self
+   */
+  public function from($source) {
+    $this->source= $source;
+    return $this;
   }
 }

--- a/src/main/php/util/address/Token.class.php
+++ b/src/main/php/util/address/Token.class.php
@@ -1,12 +1,12 @@
 <?php namespace util\address;
 
-class Pair {
+class Token {
   public $path, $content, $value;
 
   /**
-   * Creates a new pair
+   * Creates a new token
    *
-   * @param  var $path
+   * @param  string $path
    * @param  var $content
    * @param  ?array<var> $value
    */

--- a/src/main/php/util/address/XmlFile.class.php
+++ b/src/main/php/util/address/XmlFile.class.php
@@ -19,6 +19,6 @@ class XmlFile extends Address {
     $this->file= $file;
   }
 
-  /** @return php.Iterator */
-  protected function newIterator() { return new XmlIterator($this->file->in()); }
+  /** @return io.streams.InputStream */
+  protected function stream() { return $this->file->in(); }
 }

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -202,9 +202,10 @@ class XmlIterator implements Iterator {
    * @param  util.address.Definition $definition
    * @param  util.address.Address $address
    * @param  string $base
+   * @param  bool $source
    * @return var
    */
-  public function value($definition, $address, $base) {
+  public function value($definition, $address, $base, $source) {
     if (null === $this->token->source) {
       $token= $this->token;
 
@@ -215,7 +216,7 @@ class XmlIterator implements Iterator {
       // Unless we are at the end of the stream, push back last token.
       $this->valid= true;
       $this->token && array_unshift($this->tokens, $this->token);
-      $this->token= $token->from($iteration->tokens);
+      $this->token= $source ? $token->from($iteration->tokens) : $token;
       return $value;
     } else {
 

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -194,6 +194,12 @@ class XmlIterator implements Iterator {
   }
 
   /** @return void */
+  public function backup() {
+    $this->valid= true;
+    $this->token && array_unshift($this->pairs, $this->token);
+  }
+
+  /** @return void */
   #[ReturnTypeWillChange]
   public function rewind() {
     if (null !== $this->path) {

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -196,19 +196,19 @@ class XmlIterator implements Iterator {
   }
 
   /**
-   * Returns current value and stores it, returning it on subsequent calls.
+   * Creates value from definition and stores it, returning it on subsequent calls.
    *
    * @param  util.address.Definition $definition
+   * @param  util.address.Address $address
    * @param  string $base
    * @return var
    */
-  public function value($definition, $base) {
-    if (null === $definition) return $this->token->content;
-    
-    // Fetch next value, which will typically forward the cursor over all child nodes, storing
-    // the created value on the token; then back up exactly one iteration step.
+  public function value($definition, $address, $base) {
     if (null === $this->token->value) {
-      $token= new Token($this->token->path, null, [$definition->create(new Iteration($this, $base))]);
+
+      // Fetch next value, which will typically forward the cursor over all child nodes,
+      // storing the created value on the token; then back up exactly one iteration step.
+      $token= new Token($this->token->path, null, [$definition->create(new Iteration($address, $base))]);
       $this->valid= true;
       $this->token && array_unshift($this->tokens, $this->token);
       $this->token= $token;

--- a/src/main/php/util/address/XmlResource.class.php
+++ b/src/main/php/util/address/XmlResource.class.php
@@ -28,6 +28,6 @@ class XmlResource extends Address {
     $this->name= $name;
   }
 
-  /** @return php.Iterator */
-  protected function newIterator() { return new XmlIterator($this->package->getResourceAsStream($this->name)->in()); }
+  /** @return io.streams.InputStream */
+  protected function stream() { return $this->package->getResourceAsStream($this->name)->in(); }
 }

--- a/src/main/php/util/address/XmlStream.class.php
+++ b/src/main/php/util/address/XmlStream.class.php
@@ -19,6 +19,6 @@ class XmlStream extends Address {
     $this->in= $in;
   }
 
-  /** @return php.Iterator */
-  protected function newIterator() { return new XmlIterator($this->in); }
+  /** @return io.streams.InputStream */
+  protected function stream() { return $this->in; }
 }

--- a/src/main/php/util/address/XmlString.class.php
+++ b/src/main/php/util/address/XmlString.class.php
@@ -19,6 +19,6 @@ class XmlString extends Address {
     $this->stream= new MemoryInputStream($input);
   }
 
-  /** @return php.Iterator */
-  protected function newIterator() { return new XmlIterator($this->stream); }
+  /** @return io.streams.InputStream */
+  protected function stream() { return $this->stream; }
 }

--- a/src/test/php/util/address/unittest/AddressTest.class.php
+++ b/src/test/php/util/address/unittest/AddressTest.class.php
@@ -2,7 +2,7 @@
 
 use unittest\{Assert, Expect, Test};
 use util\NoSuchElementException;
-use util\address\{ArrayOf, CreationOf, Definition, Enclosing, XmlString};
+use util\address\{ArrayOf, CreationOf, Definition, XmlString};
 
 class AddressTest {
 
@@ -54,6 +54,12 @@ class AddressTest {
   }
 
   #[Test]
+  public function value() {
+    $address= new XmlString('<doc>Test</doc>');
+    Assert::equals('Test', $address->value());
+  }
+
+  #[Test]
   public function valid() {
     $address= new XmlString('<doc>Test</doc>');
     Assert::true($address->valid());
@@ -70,6 +76,13 @@ class AddressTest {
   public function valid_after_resetting() {
     $address= new XmlString('<doc>Test</doc>');
     $address->reset();
+    Assert::true($address->valid());
+  }
+
+  #[Test]
+  public function valid_after_value() {
+    $address= new XmlString('<doc>Test</doc>');
+    $address->value();
     Assert::true($address->valid());
   }
 
@@ -93,11 +106,20 @@ class AddressTest {
 
   #[Test]
   public function next_with_definition() {
-    $address= new XmlString('<doc><nested>Test</nested></doc>');
-    $value= $address->next(new Enclosing('/'))->next(new class() implements Definition {
+    $address= new XmlString('<doc>Test</doc>');
+    $value= $address->next(new class() implements Definition {
       public function create($iteration) { return [$iteration->path() => $iteration->next()]; }
     });
-    Assert::equals(['//nested' => 'Test'], $value);
+    Assert::equals(['/' => 'Test'], $value);
+  }
+
+  #[Test]
+  public function value_with_definition() {
+    $address= new XmlString('<doc>Test</doc>');
+    $value= $address->value(new class() implements Definition {
+      public function create($iteration) { return [$iteration->path() => $iteration->next()]; }
+    });
+    Assert::equals(['/' => 'Test'], $value);
   }
 
   #[Test]
@@ -110,5 +132,29 @@ class AddressTest {
   public function iteration_support_for_empty_document() {
     $address= new XmlString('<doc/>');
     Assert::equals(['/' => null], iterator_to_array($address));
+  }
+
+  #[Test]
+  public function iteration_valid_with_value() {
+    $actual= [];
+    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    foreach ($address as $path => $value) {
+      $actual[$path]= [$address->value(), $address->valid()];
+    }
+    Assert::equals(['/' => [null, true], '//a' => ['A', true], '//b' => ['B', true]], $actual);
+  }
+
+  #[Test]
+  public function iteration_valid_with_value_and_definition() {
+    $definition= new class() implements Definition {
+      public function create($iteration) { return $iteration->next(); }
+    };
+
+    $actual= [];
+    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    foreach ($address as $path => $value) {
+      $actual[$path]= [$address->value($definition), $address->valid()];
+    }
+    Assert::equals(['/' => [null, true], '//a' => ['A', true], '//b' => ['B', true]], $actual);
   }
 }

--- a/src/test/php/util/address/unittest/AddressTest.class.php
+++ b/src/test/php/util/address/unittest/AddressTest.class.php
@@ -40,10 +40,17 @@ class AddressTest {
   }
 
   #[Test, Expect(NoSuchElementException::class)]
-  public function iteration_across_end() {
+  public function next_after_end() {
     $address= new XmlString('<doc/>');
     $address->next();
     $address->next();
+  }
+
+  #[Test, Expect(NoSuchElementException::class)]
+  public function value_after_end() {
+    $address= new XmlString('<doc/>');
+    $address->next();
+    $address->value();
   }
 
   #[Test]

--- a/src/test/php/util/address/unittest/ValueOfTest.class.php
+++ b/src/test/php/util/address/unittest/ValueOfTest.class.php
@@ -145,4 +145,21 @@ class ValueOfTest {
       ]))
     );
   }
+
+  #[Test, Values([1, 2, 3])]
+  public function call_value_repeatedly($times) {
+    $definition= new ValueOf([], [
+      '@*' => function(&$self, $it, $name) { $self[$name]= $it->next(); },
+      '.'  => function(&$self, $it) { $self['name']= $it->next(); }
+    ]);
+
+    $address= new XmlString('<book asin="B01N1UPZ10" author="Test">Name</book>');
+    for ($i= 1; $i <= $times; $i++) {
+      Assert::equals(
+        ['name' => 'Name', 'asin' => 'B01N1UPZ10', 'author' => 'Test'],
+        $address->value($definition),
+        "Invocation #{$i}"
+      );
+    }
+  }
 }


### PR DESCRIPTION
...for use within foreach() loops, e.g.

```php
$address= new XmlString('<feed><channel><item id="a">A</item><item id="b">B</item></channel></feed>');
$items= [];
foreach ($address as $path => $value) {
  if ('//channel/item' === $path) {
    $items[]= $address->value(new ValueOf([], [
      '@id' => fn(&$self, $it) => $self['id']= $it->next(),
      '.'   => fn(&$self, $it) => $self['content']= $it->next(),
    ]));
  }
}
// [['id' => 'a', 'content' => 'A'], ['id' => 'b', 'content' => 'B']]
```

If the loop were to use `$address->next(new ValueOf(...))` it would forward the cursor one too many and swallow every other element!