### PR TITLE
Add Address::pointers() to iterate over paths and Pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ $definition= new ObjectOf(Item::class, [
 $conn= new HttpConnection('https://www.tagesschau.de/xml/rss2/');
 $stream= new XmlStream($conn->get()->in());
 
-Sequence::of($stream)
-  ->filter(fn($value, $path) => '//channel/item' === $path)
-  ->map(fn() => $stream->value($definition))
+Sequence::of($stream->pointers('//channel/item'))
+  ->map(fn($pointer) => $pointer->value($definition))
   ->each(fn($item) => Console::writeLine('- ', $item->title, "\n  ", $item->link))
 ;
 ```

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -35,15 +35,16 @@ abstract class Address implements IteratorAggregate {
    */
   public function pointers($filter= null) {
     $it= $this->getIterator(true);
+    $pointer= new Pointer($this);
 
     if (null === $filter) {
       while ($it->valid()) {
-        yield $it->key() => new Pointer($this);
+        yield $it->key() => $pointer;
         $it->next();
       }
     } else {
       while ($it->valid()) {
-        $filter === $it->key() && yield $filter => new Pointer($this);
+        $filter === $it->key() && yield $filter => $pointer;
         $it->next();
       }
     }

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -15,7 +15,7 @@ abstract class Address implements IteratorAggregate {
    * Gets iterator
    *
    * @param  bool $rewind Whether to initially rewind the iterator
-   * @return php.Iterator
+   * @return Traversable
    */
   public function getIterator($rewind= false): Traversable {
     if (null === $this->iterator) {
@@ -25,6 +25,28 @@ abstract class Address implements IteratorAggregate {
       }
     }
     return $this->iterator;
+  }
+
+  /**
+   * Iterate over pointers
+   *
+   * @param  ?string $filter
+   * @return iterable
+   */
+  public function pointers($filter= null) {
+    $it= $this->getIterator(true);
+
+    if (null === $filter) {
+      while ($it->valid()) {
+        yield $it->key() => new Pointer($this);
+        $it->next();
+      }
+    } else {
+      while ($it->valid()) {
+        $filter === $it->key() && yield $filter => new Pointer($this);
+        $it->next();
+      }
+    }
   }
 
   /** @return io.streams.InputStream */

--- a/src/main/php/util/address/Enclosing.class.php
+++ b/src/main/php/util/address/Enclosing.class.php
@@ -27,6 +27,6 @@ class Enclosing implements Definition {
     }
 
     $iteration->next();
-    return $iteration->input();
+    return $iteration->address();
   }
 }

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -1,31 +1,31 @@
 <?php namespace util\address;
 
 class Iteration {
-  private $input, $base;
+  private $address, $base;
   public $tokens= [];
 
   /**
    * Creates an iteration
    *
-   * @param  util.address.Address $input
+   * @param  util.address.Address $address
    * @param  string $base
    */
-  public function __construct(Address $input, $base) {
-    $this->input= $input;
+  public function __construct(Address $address, $base) {
+    $this->address= $address;
     $this->base= $base.'/';
   }
 
   /** @return util.address.Address */
-  public function input() { return $this->input; }
+  public function address() { return $this->address; }
 
   /** @return string */
   public function base() { return $this->base; }
 
   /** @return bool */
-  public function valid() { return $this->input->valid(); }
+  public function valid() { return $this->address->valid(); }
 
   /** @return string */
-  public function path() { return $this->input->path(); }
+  public function path() { return $this->address->path(); }
 
   /**
    * Returns the next value according to the given definition.
@@ -34,10 +34,10 @@ class Iteration {
    * @return var
    */
   public function next(Definition $definition= null) {
-    $it= $this->input->getIterator(true);
+    $it= $this->address->getIterator(true);
     $this->tokens[]= $it->token;
 
-    $value= null === $definition ? $it->current() : $it->value($definition, $this->input, $this->base, false);
+    $value= null === $definition ? $it->current() : $it->value($definition, $this->address, $this->base, false);
     $it->next();
     return $value;
   }

--- a/src/main/php/util/address/Pointer.class.php
+++ b/src/main/php/util/address/Pointer.class.php
@@ -1,0 +1,21 @@
+<?php namespace util\address;
+
+class Pointer {
+  private $address;
+
+  /** @param util.address.Address */
+  public function __construct($address) {
+    $this->address= $address;
+  }
+
+  /**
+   * Returns the current value according to the given definition
+   *
+   * @param  util.address.Definition $definition
+   * @return var
+   * @throws util.NoSuchElementException if there are no more elements
+   */
+  public function value(Definition $definition= null) {
+    return $this->address->value($definition);
+  }
+}

--- a/src/main/php/util/address/Pointer.class.php
+++ b/src/main/php/util/address/Pointer.class.php
@@ -16,6 +16,7 @@ class Pointer {
    * @throws util.NoSuchElementException if there are no more elements
    */
   public function value(Definition $definition= null) {
-    return $this->address->value($definition);
+    $it= $this->address->getIterator(true);
+    return null === $definition ? $it->current() : $it->value($definition, $this->address, '/', true);
   }
 }

--- a/src/main/php/util/address/Pointer.class.php
+++ b/src/main/php/util/address/Pointer.class.php
@@ -3,7 +3,7 @@
 class Pointer {
   private $address;
 
-  /** @param util.address.Address $address */
+  /** Creates a pointer to a given address */
   public function __construct(Address $address) {
     $this->address= $address;
   }

--- a/src/main/php/util/address/Pointer.class.php
+++ b/src/main/php/util/address/Pointer.class.php
@@ -3,10 +3,13 @@
 class Pointer {
   private $address;
 
-  /** @param util.address.Address */
-  public function __construct($address) {
+  /** @param util.address.Address $address */
+  public function __construct(Address $address) {
     $this->address= $address;
   }
+
+  /** @return util.address.Address */
+  public function address() { return $this->address; }
 
   /**
    * Returns the current value according to the given definition

--- a/src/test/php/util/address/unittest/AddressTest.class.php
+++ b/src/test/php/util/address/unittest/AddressTest.class.php
@@ -199,6 +199,7 @@ class AddressTest {
   #[Test]
   public function pointers() {
     $actual= [];
+
     $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
     foreach ($address->pointers() as $path => $pointer) {
       $actual[$path]= $pointer->value();
@@ -209,10 +210,23 @@ class AddressTest {
   #[Test]
   public function filtered_pointers() {
     $actual= [];
+
     $address= new XmlString('<tests><unit>A</unit><unit>B</unit><integration>C</integration></tests>');
     foreach ($address->pointers('//unit') as $path => $pointer) {
       $actual[]= $pointer->value();
     }
     Assert::equals(['A', 'B'], $actual);
+  }
+
+  #[Test]
+  public function pointers_with_definition() {
+    $definition= $this->asMap();
+    $actual= [];
+
+    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    foreach ($address->pointers() as $path => $pointer) {
+      $actual+= $pointer->value($definition);
+    }
+    Assert::equals(['/' => null, '//a' => 'A', '//b' => 'B'], $actual);
   }
 }

--- a/src/test/php/util/address/unittest/AddressTest.class.php
+++ b/src/test/php/util/address/unittest/AddressTest.class.php
@@ -229,4 +229,16 @@ class AddressTest {
     }
     Assert::equals(['/' => null, '//a' => 'A', '//b' => 'B'], $actual);
   }
+
+  #[Test]
+  public function pointers_can_resume() {
+    $actual= [];
+
+    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address->next();
+    foreach ($address->pointers() as $path => $pointer) {
+      $actual[$path]= $pointer->value();
+    }
+    Assert::equals(['//a' => 'A', '//b' => 'B'], $actual);
+  }
 }

--- a/src/test/php/util/address/unittest/AddressTest.class.php
+++ b/src/test/php/util/address/unittest/AddressTest.class.php
@@ -195,4 +195,24 @@ class AddressTest {
     }
     Assert::equals(['/' => [null, true], '//a' => ['A', true], '//b' => ['B', true]], $actual);
   }
+
+  #[Test]
+  public function pointers() {
+    $actual= [];
+    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    foreach ($address->pointers() as $path => $pointer) {
+      $actual[$path]= $pointer->value();
+    }
+    Assert::equals(['/' => null, '//a' => 'A', '//b' => 'B'], $actual);
+  }
+
+  #[Test]
+  public function filtered_pointers() {
+    $actual= [];
+    $address= new XmlString('<tests><unit>A</unit><unit>B</unit><integration>C</integration></tests>');
+    foreach ($address->pointers('//unit') as $path => $pointer) {
+      $actual[]= $pointer->value();
+    }
+    Assert::equals(['A', 'B'], $actual);
+  }
 }


### PR DESCRIPTION
## Example
Before, we need the *XmlStream* instance to create the value:

```php
$stream= new XmlStream(...);
foreach ($stream as $path => $node) {
  if ('//channel/item' === $path) {
    Console::writeLine($stream->value($definition));
  }
}
```

By using `pointers()`, we can create *Pointer* instances and fetch values from them, so we don't need to keep a reference to the stream any longer:

```php
foreach ((new XmlStream(...))->pointers() as $path => $pointer) {
  if ('//channel/item' === $path) {
    Console::writeLine($pointer->value($definition));
  }
}
```

The `pointers()` iterator also comes with an optional filter:

```php
foreach ((new XmlStream(...))->pointers('//channel/item') as $path => $pointer) {
  Console::writeLine($pointer->value($definition));
}
```
