### PR TITLE
Initial support for inline doctype and entities

### DIFF
--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -126,7 +126,7 @@ class XmlIterator implements Iterator {
   protected function doctype($declaration) {
     preg_match_all('/<!ENTITY ([^ ]+) "([^"]+)">/', $declaration, $matches, PREG_SET_ORDER);
     foreach ($matches as $match) {
-      $this->entities[$match[1]]= $match[2];
+      $this->entities[$match[1]]= $this->decode($match[2]);
     }
   }
 

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -129,14 +129,10 @@ class XmlIterator implements Iterator {
     // No need to support parameter entities, see https://stackoverflow.com/a/39549669
     preg_match_all('/<!ENTITY\s+([^ ]+)\s+"([^"]+)">/', $declaration, $matches, PREG_SET_ORDER);
 
-    // Convert encoding and decode known entities referenced inside declarations first
+    // Decode known entities referenced inside declarations first
     $declarations= [];
     foreach ($matches as $match) {
-      $declarations[$match[1]]= html_entity_decode(
-        $this->encoding === \xp::ENCODING ? $match[2] : iconv($this->encoding, \xp::ENCODING, $match[2]),
-        ENT_XML1 | ENT_SUBSTITUTE,
-        \xp::ENCODING
-      );
+      $declarations[$match[1]]= html_entity_decode($match[2], ENT_XML1 | ENT_SUBSTITUTE, \xp::ENCODING);
     }
 
     // The only entities left over now are references to the one inside this DTD.

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -118,13 +118,19 @@ class XmlIterator implements Iterator {
   }
 
   /**
-   * Handle doctype
+   * Handle doctype, parsing its internal entities declarations.
    *
    * @param  string $declaration
    * @return void
    */
   protected function doctype($declaration) {
     preg_match_all('/<!ENTITY ([^ ]+) "([^"]+)">/', $declaration, $matches, PREG_SET_ORDER);
+
+    // Register all entities, then decode them. This allows referencing
+    // entities within entities without having to follow a specific order.
+    foreach ($matches as $match) {
+      $this->entities[$match[1]]= $match[2];
+    }
     foreach ($matches as $match) {
       $this->entities[$match[1]]= $this->decode($match[2]);
     }

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -237,7 +237,9 @@ class XmlIterator implements Iterator {
             } else if (0 === strncmp('!--', $tag, 3)) {
               $this->comment($this->tokenUntil(substr($tag, 3), '-->'));
             } else if (0 === strncmp('!DOCTYPE', $tag, 8)) {
-              $this->doctype($this->tokenUntil(substr($tag, strpos($tag, '[', 8) + 1), ']>'));
+              if (false !== ($p= strpos($tag, '[', 8))) {
+                $this->doctype($this->tokenUntil(substr($tag, $p + 1), ']>'));
+              }
             } else {
               throw new IllegalStateException('Cannot handle '.$tag);
             }

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -124,7 +124,9 @@ class XmlIterator implements Iterator {
    * @return void
    */
   protected function doctype($declaration) {
-    preg_match_all('/<!ENTITY ([^ ]+) "([^"]+)">/', $declaration, $matches, PREG_SET_ORDER);
+
+    // No need to support parameter entities, see https://stackoverflow.com/a/39549669
+    preg_match_all('/<!ENTITY\s+([^ ]+)\s+"([^"]+)">/', $declaration, $matches, PREG_SET_ORDER);
 
     // Register all entities, then decode them. This allows referencing
     // entities within entities without having to follow a specific order.

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -124,6 +124,20 @@ class XmlIteratorTest {
     );
   }
 
+  #[Test]
+  public function entities_are_case_sensitive() {
+    $this->assertIterated(
+      [['/' => 'lower and upper case']],
+      new XmlIterator(new MemoryInputStream('
+        <!DOCTYPE binford [
+          <!ENTITY case "lower">
+          <!ENTITY Case "upper">
+        ]>
+        <test>&case; and &Case; case</test>
+      '))
+    );
+  }
+
   #[Test, Expect(class: FormatException::class, withMessage: 'Entity &missing; not defined')]
   public function raises_error_for_missing_entities() {
     iterator_count(new XmlIterator(new MemoryInputStream('

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -137,6 +137,19 @@ class XmlIteratorTest {
     );
   }
 
+  #[Test, Values(['SYSTEM "http://www.xmlwriter.net/copyright.xml"', 'PUBLIC "-//W3C//TEXT copyright//EN" "http://www.w3.org/xmlspec/copyright.xml"'])]
+  public function ignores_external_entity($declaration) {
+    $this->assertIterated(
+      [['/' => '&c;']],
+      new XmlIterator(new MemoryInputStream('
+        <!DOCTYPE external [
+          <!ENTITY c '.$declaration.'>
+        ]>
+        <external>&c;</external>
+      '))
+    );
+  }
+
   #[Test, Values(['<char>&#xDC;</char>', '<char>&#xdc;</char>', '<char>&#220;</char>'])]
   public function numeric_entity_handled($xml) {
     $this->assertIterated(

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -107,6 +107,20 @@ class XmlIteratorTest {
     );
   }
 
+  #[Test]
+  public function entities_from_doctype() {
+    $this->assertIterated(
+      [['/' => 'Copyright 2021'], ['//@power' => '6100']],
+      new XmlIterator(new MemoryInputStream('
+        <!DOCTYPE books [
+          <!ENTITY more "6100">
+          <!ENTITY copy "Copyright">
+        ]>
+        <book power="&more;">&copy; 2021</book>
+      '))
+    );
+  }
+
   #[Test, Values(['<char>&#xDC;</char>', '<char>&#xdc;</char>', '<char>&#220;</char>'])]
   public function numeric_entity_handled($xml) {
     $this->assertIterated(

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -110,15 +110,15 @@ class XmlIteratorTest {
   #[Test]
   public function entities_from_doctype() {
     $this->assertIterated(
-      [['/' => 'Binford 6100 - Copyright 2021'], ['//@power' => '6100'], ['//@price' => '.99 €']],
+      [['/' => 'Binford 6100 Tools - Copyright 2021'], ['//@power' => '6100'], ['//@price' => '.99 €']],
       new XmlIterator(new MemoryInputStream('
         <!DOCTYPE binford [
-          <!ENTITY euro "&#8364;">
-          <!ENTITY name "Binford &more;">
-          <!ENTITY more "6100">
-          <!ENTITY copy "Copyright">
+          <!ENTITY euro   "&#8364;">
+          <!ENTITY prefix "Binford &more;">
+          <!ENTITY more   "6100">
+          <!ENTITY copy   "Copyright">
         ]>
-        <binford power="&more;" price=".99 &euro;">&name; - &copy; 2021</binford>
+        <binford power="&more;" price=".99 &euro;">&prefix; Tools - &copy; 2021</binford>
       '))
     );
   }

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -221,10 +221,32 @@ class XmlIteratorTest {
   }
 
   #[Test, Values([['', "<char>\303\234</char>"], ['', "<char><![CDATA[\303\234]]></char>"], ['encoding="utf-8"', "<char>\303\234</char>"], ['encoding="utf-8"', "<char><![CDATA[\303\234]]></char>"], ['encoding="iso-8859-1"', "<char>\334</char>"], ['encoding="iso-8859-1"', "<char><![CDATA[\334]]></char>"]])]
-  public function encoding_handled($encoding, $xml) {
+  public function encoding_handled_in_content($encoding, $xml) {
     $this->assertIterated(
       [['/' => 'Ü']],
       new XmlIterator(new MemoryInputStream('<?xml version="1.0" '.$encoding.'?>'.$xml))
+    );
+  }
+
+  #[Test, Values([['', "<char id='\303\234'/>"], ['encoding="utf-8"', "<char id='\303\234'/>"], ['encoding="iso-8859-1"', "<char id='\334'/>"]])]
+  public function encoding_handled_in_attributes($encoding, $xml) {
+    $this->assertIterated(
+      [['/' => null], ['//@id' => 'Ü']],
+      new XmlIterator(new MemoryInputStream('<?xml version="1.0" '.$encoding.'?>'.$xml))
+    );
+  }
+
+  #[Test, Values([['', "\303\234"], ['encoding="utf-8"', "\303\234"], ['encoding="iso-8859-1"', "\334"]])]
+  public function encoding_handled_in_doctype_entities($encoding, $cdata) {
+    $this->assertIterated(
+      [['/' => 'Ü']],
+      new XmlIterator(new MemoryInputStream('
+        <?xml version="1.0" '.$encoding.'?>
+        <!DOCTYPE test [
+          <!ENTITY Uuml "'.$cdata.'">
+        ]>
+        <test>&Uuml;</test>
+      '))
     );
   }
 

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -169,6 +169,18 @@ class XmlIteratorTest {
     );
   }
 
+  #[Test, Values(['html SYSTEM "html.dtd"', 'HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
+  "http://www.w3.org/TR/REC-html40/loose.dtd"'])]
+  public function ignores_external_dtd($declaration) {
+    $this->assertIterated(
+      [['/' => '&c;']],
+      new XmlIterator(new MemoryInputStream('
+        <!DOCTYPE '.$declaration.'>
+        <html>&c;</html>
+      '))
+    );
+  }
+
   #[Test, Values(['<char>&#xDC;</char>', '<char>&#xdc;</char>', '<char>&#220;</char>'])]
   public function numeric_entity_handled($xml) {
     $this->assertIterated(

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -169,8 +169,7 @@ class XmlIteratorTest {
     );
   }
 
-  #[Test, Values(['html SYSTEM "html.dtd"', 'HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-  "http://www.w3.org/TR/REC-html40/loose.dtd"'])]
+  #[Test, Values(['html SYSTEM "html.dtd"', 'HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd"'])]
   public function ignores_external_dtd($declaration) {
     $this->assertIterated(
       [['/' => '&c;']],

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -169,7 +169,7 @@ class XmlIteratorTest {
     );
   }
 
-  #[Test, Values(['SYSTEM "http://www.xmlwriter.net/copyright.xml"', 'PUBLIC "-//W3C//TEXT copyright//EN" "http://www.w3.org/xmlspec/copyright.xml"'])]
+  #[Test, Values(['SYSTEM "copyright.xml"', 'PUBLIC "-//W3C//TEXT copyright//EN" "http://www.w3.org/xmlspec/copyright.xml"'])]
   public function ignores_external_entity($declaration) {
     $this->assertIterated(
       [['/' => '&c;']],
@@ -182,15 +182,9 @@ class XmlIteratorTest {
     );
   }
 
-  #[Test, Values(['html SYSTEM "html.dtd"', 'HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd"'])]
-  public function ignores_external_dtd($declaration) {
-    $this->assertIterated(
-      [['/' => '&c;']],
-      new XmlIterator(new MemoryInputStream('
-        <!DOCTYPE '.$declaration.'>
-        <html>&c;</html>
-      '))
-    );
+  #[Test, Expect(IllegalStateException::class), Values(['html SYSTEM "html.dtd"', 'HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd"'])]
+  public function does_not_support_external_dtds($declaration) {
+    iterator_count(new XmlIterator(new MemoryInputStream('<!DOCTYPE '.$declaration.'><html>...</html>')));
   }
 
   #[Test, Values(['<char>&#xDC;</char>', '<char>&#xdc;</char>', '<char>&#220;</char>'])]

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -123,6 +123,20 @@ class XmlIteratorTest {
     );
   }
 
+  #[Test]
+  public function does_not_choke_on_recursion() {
+    $this->assertIterated(
+      [['/' => 'Jo Smith user@user.com Jo Smith &email;']],
+      new XmlIterator(new MemoryInputStream('
+        <!DOCTYPE recursion [
+          <!ENTITY email "user@user.com &js;">
+          <!ENTITY js "Jo Smith &email;">
+        ]>
+        <recursion>&js;</recursion>
+      '))
+    );
+  }
+
   #[Test, Values(['<char>&#xDC;</char>', '<char>&#xdc;</char>', '<char>&#220;</char>'])]
   public function numeric_entity_handled($xml) {
     $this->assertIterated(

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -110,14 +110,15 @@ class XmlIteratorTest {
   #[Test]
   public function entities_from_doctype() {
     $this->assertIterated(
-      [['/' => 'Copyright 2021'], ['//@power' => '6100'], ['//@price' => '.99 €']],
+      [['/' => 'Binford 6100 - Copyright 2021'], ['//@power' => '6100'], ['//@price' => '.99 €']],
       new XmlIterator(new MemoryInputStream('
         <!DOCTYPE binford [
           <!ENTITY euro "&#8364;">
+          <!ENTITY name "Binford &more;">
           <!ENTITY more "6100">
           <!ENTITY copy "Copyright">
         ]>
-        <binford power="&more;" price=".99 &euro;">&copy; 2021</binford>
+        <binford power="&more;" price=".99 &euro;">&name; - &copy; 2021</binford>
       '))
     );
   }

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -156,6 +156,19 @@ class XmlIteratorTest {
     ')));
   }
 
+  #[Test]
+  public function ignores_parameter_entities() {
+    $this->assertIterated(
+      [['/' => 'Jo Smith %param;']],
+      new XmlIterator(new MemoryInputStream('
+        <!DOCTYPE test [
+          <!ENTITY js "Jo Smith %param;">
+        ]>
+        <test>&js;</test>
+      '))
+    );
+  }
+
   #[Test, Values(['SYSTEM "http://www.xmlwriter.net/copyright.xml"', 'PUBLIC "-//W3C//TEXT copyright//EN" "http://www.w3.org/xmlspec/copyright.xml"'])]
   public function ignores_external_entity($declaration) {
     $this->assertIterated(

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -110,13 +110,14 @@ class XmlIteratorTest {
   #[Test]
   public function entities_from_doctype() {
     $this->assertIterated(
-      [['/' => 'Copyright 2021'], ['//@power' => '6100']],
+      [['/' => 'Copyright 2021'], ['//@power' => '6100'], ['//@price' => '.99 €']],
       new XmlIterator(new MemoryInputStream('
-        <!DOCTYPE books [
+        <!DOCTYPE binford [
+          <!ENTITY euro "&#8364;">
           <!ENTITY more "6100">
           <!ENTITY copy "Copyright">
         ]>
-        <book power="&more;">&copy; 2021</book>
+        <binford power="&more;" price=".99 &euro;">&copy; 2021</binford>
       '))
     );
   }


### PR DESCRIPTION
## Example

```xml
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE binford [
  <!ENTITY euro "&#8364;">
  <!ENTITY name "Binford &more;">
  <!ENTITY more "6100">
  <!ENTITY copy "Copyright">
]>
<binford power="&more;" price=".99 &euro;">&name; - &copy; 2021</binford>
```

Iteration yields the following:

```php
['/' => 'Binford 6100 - Copyright 2021']
['//@power' => '6100']
['//@price' => '.99 €']
```

## Notes

* Doesn't support external DTDs and raises exceptions if it encounters these
* Doesn't support external entities in inline DTDs such as `<!ENTITY SYSTEM "http://www.xmlwriter.net/copyright.xml">` for [security reasons](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing) and ignores these

See #12