### PR TITLE
Join various input sources into one new API: XmlStreaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ class Author {
 ...the following will map the XML to an object instance while reading it from the socket.
 
 ```php
-use util\address\{XmlStream, ObjectOf};
+use util\address\{XmlStreaming, ObjectOf};
 
 $socket= /* ... */
 
-$address= new XmlStream($socket->in());
+$address= new XmlStreaming($socket);
 $book= $address->next(new ObjectOf(Book::class, [
   'name'   => fn($self) => $self->name= yield,
   'author' => fn($self) => $self->author= yield new ObjectOf(Author::class, [
@@ -70,22 +70,22 @@ Definitions are used to create structured data from the XML input. Here are all 
 Simplemost version which is given a seed value, which it can modify through the given address functions.
 
 ```php
-use util\address\{XmlString, ValueOf};
+use util\address\{XmlStreaming, ValueOf};
 
 // Parse into string 'Tim Taylor'
-$xml= new XmlString('<name>Tim Taylor</name>');
+$xml= new XmlStreaming('<name>Tim Taylor</name>');
 $name= $xml->next(new ValueOf(null, [
   '.' => fn(&$self) => $self= yield,
 ]);
 
 // Parse into array ['More', 'Power']
-$xml= new XmlString('<tools><tool>More</tool><tool>Power</tool></tools>');
+$xml= new XmlStreaming('<tools><tool>More</tool><tool>Power</tool></tools>');
 $name= $xml->next(new ValueOf([], [
   'tool' => fn(&$self) => $self[]= yield,
 ]);
 
 // Parse into map ['id' => 6100, 'name' => 'more power']
-$xml= new XmlString('<tool id="6100">more power</tool>');
+$xml= new XmlStreaming('<tool id="6100">more power</tool>');
 $book= $xml->next(new ValueOf([], [
   '@id' => fn(&$self) => $self['id']= (int)yield,
   '.'   => fn(&$self) => $self['name']= yield,
@@ -97,14 +97,14 @@ $book= $xml->next(new ValueOf([], [
 Creates objects without invoking their constructors. Modifies the members directly, including non-public ones.
 
 ```php
-use util\address\{XmlString, ObjectOf};
+use util\address\{XmlStreaming, ObjectOf};
 
 class Book {
   public $isbn, $name;
 }
 
 // Parse into Book(isbn: '978-0552151740', name: 'A Short History...')
-$xml= new XmlString('<book isbn="978-0552151740"><name>A Short History...</name></book>');
+$xml= new XmlStreaming('<book isbn="978-0552151740"><name>A Short History...</name></book>');
 $book= $xml->next(new ObjectOf(Book::class, [
   '@isbn' => fn($self) => $self->isbn= yield,
   'name'  => fn($self) => $self->name= yield,
@@ -116,7 +116,7 @@ $book= $xml->next(new ObjectOf(Book::class, [
 Works with *record* classes, which are defined as being immutable and having an all-arg constructor. Modifies the named constructor arguments.
 
 ```php
-use util\address\{XmlString, RecordOf};
+use util\address\{XmlStreaming, RecordOf};
 
 class Book {
   public function __construct(private string $isbn, private string $name) { }
@@ -126,7 +126,7 @@ class Book {
 }
 
 // Parse into Book(isbn: '978-0552151740', name: 'A Short History...')
-$xml= new XmlString('<book isbn="978-0552151740"><name>A Short History...</name></book>');
+$xml= new XmlStreaming('<book isbn="978-0552151740"><name>A Short History...</name></book>');
 $book= $xml->next(new RecordOf(Book::class, [
   '@isbn' => fn(&$args) => $args['isbn']= yield,
   'name'  => fn(&$args) => $args['name']= yield,

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ use util\address\{XmlStreaming, ObjectOf};
 
 $socket= /* ... */
 
-$address= new XmlStreaming($socket);
-$book= $address->next(new ObjectOf(Book::class, [
+$stream= new XmlStreaming($socket);
+$book= $stream->next(new ObjectOf(Book::class, [
   'name'   => fn($self) => $self->name= yield,
   'author' => fn($self) => $self->author= yield new ObjectOf(Author::class, [
     'name'   => fn($self) => $self->name= yield ?: '(unknown author)'; }
@@ -73,20 +73,20 @@ Simplemost version which is given a seed value, which it can modify through the 
 use util\address\{XmlStreaming, ValueOf};
 
 // Parse into string 'Tim Taylor'
-$xml= new XmlStreaming('<name>Tim Taylor</name>');
-$name= $xml->next(new ValueOf(null, [
+$stream= new XmlStreaming('<name>Tim Taylor</name>');
+$name= $stream->next(new ValueOf(null, [
   '.' => fn(&$self) => $self= yield,
 ]);
 
 // Parse into array ['More', 'Power']
-$xml= new XmlStreaming('<tools><tool>More</tool><tool>Power</tool></tools>');
-$name= $xml->next(new ValueOf([], [
+$stream= new XmlStreaming('<tools><tool>More</tool><tool>Power</tool></tools>');
+$name= $stream->next(new ValueOf([], [
   'tool' => fn(&$self) => $self[]= yield,
 ]);
 
 // Parse into map ['id' => 6100, 'name' => 'more power']
-$xml= new XmlStreaming('<tool id="6100">more power</tool>');
-$book= $xml->next(new ValueOf([], [
+$stream= new XmlStreaming('<tool id="6100">more power</tool>');
+$book= $stream->next(new ValueOf([], [
   '@id' => fn(&$self) => $self['id']= (int)yield,
   '.'   => fn(&$self) => $self['name']= yield,
 ]);
@@ -104,8 +104,8 @@ class Book {
 }
 
 // Parse into Book(isbn: '978-0552151740', name: 'A Short History...')
-$xml= new XmlStreaming('<book isbn="978-0552151740"><name>A Short History...</name></book>');
-$book= $xml->next(new ObjectOf(Book::class, [
+$stream= new XmlStreaming('<book isbn="978-0552151740"><name>A Short History...</name></book>');
+$book= $stream->next(new ObjectOf(Book::class, [
   '@isbn' => fn($self) => $self->isbn= yield,
   'name'  => fn($self) => $self->name= yield,
 ]);
@@ -126,8 +126,8 @@ class Book {
 }
 
 // Parse into Book(isbn: '978-0552151740', name: 'A Short History...')
-$xml= new XmlStreaming('<book isbn="978-0552151740"><name>A Short History...</name></book>');
-$book= $xml->next(new RecordOf(Book::class, [
+$stream= new XmlStreaming('<book isbn="978-0552151740"><name>A Short History...</name></book>');
+$book= $stream->next(new RecordOf(Book::class, [
   '@isbn' => fn(&$args) => $args['isbn']= yield,
   'name'  => fn(&$args) => $args['name']= yield,
 ]);

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -20,6 +20,6 @@ abstract class Address extends Streaming {
    * Creates an iterator. Default implementation is to return an
    * `XmlIterator` instance for BC reasons.
    */
-  protected function iterator(): Iterator { return new XmlIterator($this->stream()); }
+  public function iterator(): Iterator { return new XmlIterator($this->stream()); }
 
 }

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -1,6 +1,7 @@
 <?php namespace util\address;
 
-use IteratorAggregate, Traversable;
+use Iterator, IteratorAggregate, Traversable;
+use lang\IllegalStateException;
 use util\NoSuchElementException;
 
 /**
@@ -12,6 +13,22 @@ abstract class Address implements IteratorAggregate {
   private $iterator;
 
   /**
+   * Returns a stream
+   *
+   * @deprecated Implement iterator() instead!
+   * @return io.streams.InputStream
+   */
+  protected function stream() {
+    throw new IllegalStateException('Implement either stream() or iterator() in subclasses');
+  }
+
+  /**
+   * Creates an iterator. Default implementation is to return an
+   * `XmlIterator` instance for BC reasons.
+   */
+  protected function iterator(): Iterator { return new XmlIterator($this->stream()); }
+
+  /**
    * Gets iterator
    *
    * @param  bool $rewind Whether to initially rewind the iterator
@@ -19,7 +36,7 @@ abstract class Address implements IteratorAggregate {
    */
   public function getIterator($rewind= false): Traversable {
     if (null === $this->iterator) {
-      $this->iterator= new XmlIterator($this->stream());
+      $this->iterator= $this->iterator();
       if ($rewind) {
         $this->iterator->rewind();
       }
@@ -49,9 +66,6 @@ abstract class Address implements IteratorAggregate {
       }
     }
   }
-
-  /** @return io.streams.InputStream */
-  protected abstract function stream();
 
   /**
    * Reset this input

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -1,16 +1,30 @@
 <?php namespace util\address;
 
 use Iterator, IteratorAggregate, Traversable;
-use lang\IllegalStateException;
-use util\NoSuchElementException;
+use io\Channel;
+use io\streams\{InputStream, MemoryInputStream};
+use lang\{Closeable, Value};
+use util\{NoSuchElementException, Objects};
 
 /**
  * Base class for all XML inputs
  *
  * @test  xp://util.address.unittest.AddressTest
  */
-abstract class Address implements IteratorAggregate {
+abstract class Address implements Closeable, Value, IteratorAggregate {
   private $iterator;
+  protected $stream;
+
+  /** @param string|io.Channel|io.streams.InputStream $source */
+  public function __construct($source) {
+    if ($source instanceof InputStream) {
+      $this->stream= $source;
+    } else if ($source instanceof Channel) {
+      $this->stream= $source->in();
+    } else {
+      $this->stream= new MemoryInputStream($source);
+    }
+  }
 
   /**
    * Returns a stream
@@ -18,9 +32,7 @@ abstract class Address implements IteratorAggregate {
    * @deprecated Implement iterator() instead!
    * @return io.streams.InputStream
    */
-  protected function stream() {
-    throw new IllegalStateException('Implement either stream() or iterator() in subclasses');
-  }
+  protected function stream() { return $this->stream; }
 
   /**
    * Creates an iterator. Default implementation is to return an
@@ -124,4 +136,34 @@ abstract class Address implements IteratorAggregate {
 
     throw new NoSuchElementException('No more elements in iterator');
   }
+
+  /** @return string */
+  public function toString() {
+
+    // Most InputStream instances have a toString() method but do not implement
+    // the Value interface, see https://github.com/xp-framework/core/issues/310
+    if ($this->stream instanceof Value || method_exists($this->stream, 'toString')) {
+      return nameof($this).'<'.$this->stream->toString().'>';
+    } else {
+      return nameof($this).'<'.Objects::stringOf($this->stream).'>';
+    }
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'XS'.Objects::hashOf($this->stream);
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
+  }
+
+  /** @return void */
+  public function close() { $this->stream->close(); }
 }

--- a/src/main/php/util/address/Address.class.php
+++ b/src/main/php/util/address/Address.class.php
@@ -1,35 +1,17 @@
 <?php namespace util\address;
 
-use Iterator, IteratorAggregate, Traversable;
-use io\Channel;
-use io\streams\{InputStream, MemoryInputStream};
-use lang\{Closeable, Value};
-use util\{NoSuchElementException, Objects};
+use Iterator;
 
 /**
  * Base class for all XML inputs
  *
- * @test  xp://util.address.unittest.AddressTest
+ * @deprecated Inherit from util.address.Streaming instead! 
  */
-abstract class Address implements Closeable, Value, IteratorAggregate {
-  private $iterator;
-  protected $stream;
-
-  /** @param string|io.Channel|io.streams.InputStream $source */
-  public function __construct($source) {
-    if ($source instanceof InputStream) {
-      $this->stream= $source;
-    } else if ($source instanceof Channel) {
-      $this->stream= $source->in();
-    } else {
-      $this->stream= new MemoryInputStream($source);
-    }
-  }
+abstract class Address extends Streaming {
 
   /**
    * Returns a stream
    *
-   * @deprecated Implement iterator() instead!
    * @return io.streams.InputStream
    */
   protected function stream() { return $this->stream; }
@@ -40,130 +22,4 @@ abstract class Address implements Closeable, Value, IteratorAggregate {
    */
   protected function iterator(): Iterator { return new XmlIterator($this->stream()); }
 
-  /**
-   * Gets iterator
-   *
-   * @param  bool $rewind Whether to initially rewind the iterator
-   * @return Traversable
-   */
-  public function getIterator($rewind= false): Traversable {
-    if (null === $this->iterator) {
-      $this->iterator= $this->iterator();
-      if ($rewind) {
-        $this->iterator->rewind();
-      }
-    }
-    return $this->iterator;
-  }
-
-  /**
-   * Iterate over pointers
-   *
-   * @param  ?string $filter
-   * @return iterable
-   */
-  public function pointers($filter= null) {
-    $it= $this->getIterator(true);
-    $pointer= new Pointer($this);
-
-    if (null === $filter) {
-      while ($it->valid()) {
-        yield $it->key() => $pointer;
-        $it->next();
-      }
-    } else {
-      while ($it->valid()) {
-        $filter === $it->key() && yield $filter => $pointer;
-        $it->next();
-      }
-    }
-  }
-
-  /**
-   * Reset this input
-   *
-   * @throws lang.IllegalStateException if underlying source is not seekable
-   */
-  public function reset() {
-    $this->getIterator()->rewind();
-  }
-
-  /**
-   * Checks whether there are more elements in this iteration
-   *
-   * @return bool
-   */
-  public function valid() {
-    return $this->getIterator(true)->valid();
-  }
-
-  /** @return string */
-  public function path() {
-    $it= $this->getIterator(true);
-    return $it->valid() ? $it->key() : null;
-  }
-
-  /**
-   * Returns the current value according to the given definition
-   *
-   * @param  util.address.Definition $definition
-   * @return var
-   * @throws util.NoSuchElementException if there are no more elements
-   */
-  public function value(Definition $definition= null) {
-    $it= $this->getIterator(true);
-    if ($it->valid()) {
-      return null === $definition ? $it->current() : $it->value($definition, $this, true);
-    }
-
-    throw new NoSuchElementException('No more elements in iterator');    
-  }
-
-  /**
-   * Returns the next value according to the given definition
-   *
-   * @param  util.address.Definition $definition
-   * @return var
-   * @throws util.NoSuchElementException if there are no more elements
-   */
-  public function next(Definition $definition= null) {
-    $it= $this->getIterator(true);
-    if ($it->valid()) {
-      $value= null === $definition ? $it->current() : $it->value($definition, $this, false);
-      $it->next();
-      return $value;
-    }
-
-    throw new NoSuchElementException('No more elements in iterator');
-  }
-
-  /** @return string */
-  public function toString() {
-
-    // Most InputStream instances have a toString() method but do not implement
-    // the Value interface, see https://github.com/xp-framework/core/issues/310
-    if ($this->stream instanceof Value || method_exists($this->stream, 'toString')) {
-      return nameof($this).'<'.$this->stream->toString().'>';
-    } else {
-      return nameof($this).'<'.Objects::stringOf($this->stream).'>';
-    }
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return 'XS'.Objects::hashOf($this->stream);
-  }
-
-  /**
-   * Comparison
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
-  }
-
-  /** @return void */
-  public function close() { $this->stream->close(); }
 }

--- a/src/main/php/util/address/Iteration.class.php
+++ b/src/main/php/util/address/Iteration.class.php
@@ -1,27 +1,27 @@
 <?php namespace util\address;
 
 class Iteration {
-  private $address;
+  private $streaming;
   public $tokens= [];
 
   /**
    * Creates an iteration
    *
-   * @param  util.address.Address $address
+   * @param  util.address.Streaming $streaming
    * @param  string $base
    */
-  public function __construct(Address $address) {
-    $this->address= $address;
+  public function __construct(Streaming $streaming) {
+    $this->streaming= $streaming;
   }
 
-  /** @return util.address.Address */
-  public function address() { return $this->address; }
+  /** @return util.address.Streaming */
+  public function streaming() { return $this->streaming; }
 
   /** @return bool */
-  public function valid() { return $this->address->valid(); }
+  public function valid() { return $this->streaming->valid(); }
 
   /** @return string */
-  public function path() { return $this->address->path(); }
+  public function path() { return $this->streaming->path(); }
 
   /**
    * Returns the next value according to the given definition.
@@ -30,10 +30,10 @@ class Iteration {
    * @return var
    */
   public function next(Definition $definition= null) {
-    $it= $this->address->getIterator(true);
+    $it= $this->streaming->getIterator(true);
     $this->tokens[]= $it->token;
 
-    $value= null === $definition ? $it->current() : $it->value($definition, $this->address, false);
+    $value= null === $definition ? $it->current() : $it->value($definition, $this->streaming, false);
     $it->next();
     return $value;
   }

--- a/src/main/php/util/address/Pointer.class.php
+++ b/src/main/php/util/address/Pointer.class.php
@@ -1,15 +1,15 @@
 <?php namespace util\address;
 
 class Pointer {
-  private $address;
+  private $streaming;
 
-  /** Creates a pointer to a given address */
-  public function __construct(Address $address) {
-    $this->address= $address;
+  /** Creates a pointer to a given streaming */
+  public function __construct(streaming $streaming) {
+    $this->streaming= $streaming;
   }
 
-  /** @return util.address.Address */
-  public function address() { return $this->address; }
+  /** @return util.address.Streaming */
+  public function streaming() { return $this->streaming; }
 
   /**
    * Returns the current value according to the given definition
@@ -19,7 +19,7 @@ class Pointer {
    * @throws util.NoSuchElementException if there are no more elements
    */
   public function value(Definition $definition= null) {
-    $it= $this->address->getIterator(true);
-    return null === $definition ? $it->current() : $it->value($definition, $this->address, true);
+    $it= $this->streaming->getIterator(true);
+    return null === $definition ? $it->current() : $it->value($definition, $this->streaming, true);
   }
 }

--- a/src/main/php/util/address/Streaming.class.php
+++ b/src/main/php/util/address/Streaming.class.php
@@ -1,0 +1,158 @@
+<?php namespace util\address;
+
+use Iterator, IteratorAggregate, Traversable;
+use io\Channel;
+use io\streams\{InputStream, MemoryInputStream};
+use lang\{Closeable, Value};
+use util\{NoSuchElementException, Objects};
+
+/**
+ * Base class for all streaming inputs
+ *
+ * @test  util.address.unittest.StreamingTest
+ */
+abstract class Streaming implements Closeable, Value, IteratorAggregate {
+  private $iterator;
+  protected $stream;
+
+  /** @param string|io.Channel|io.streams.InputStream $source */
+  public function __construct($source) {
+    if ($source instanceof InputStream) {
+      $this->stream= $source;
+    } else if ($source instanceof Channel) {
+      $this->stream= $source->in();
+    } else {
+      $this->stream= new MemoryInputStream($source);
+    }
+  }
+
+  /** Returns the iterator implementation */ 
+  protected abstract function iterator(): Iterator;
+
+  /**
+   * Gets iterator
+   *
+   * @param  bool $rewind Whether to initially rewind the iterator
+   * @return Traversable
+   */
+  public function getIterator($rewind= false): Traversable {
+    if (null === $this->iterator) {
+      $this->iterator= $this->iterator();
+      if ($rewind) {
+        $this->iterator->rewind();
+      }
+    }
+    return $this->iterator;
+  }
+
+  /**
+   * Iterate over pointers
+   *
+   * @param  ?string $filter
+   * @return iterable
+   */
+  public function pointers($filter= null) {
+    $it= $this->getIterator(true);
+    $pointer= new Pointer($this);
+
+    if (null === $filter) {
+      while ($it->valid()) {
+        yield $it->key() => $pointer;
+        $it->next();
+      }
+    } else {
+      while ($it->valid()) {
+        $filter === $it->key() && yield $filter => $pointer;
+        $it->next();
+      }
+    }
+  }
+
+  /**
+   * Reset this input
+   *
+   * @throws lang.IllegalStateException if underlying source is not seekable
+   */
+  public function reset() {
+    $this->getIterator()->rewind();
+  }
+
+  /**
+   * Checks whether there are more elements in this iteration
+   *
+   * @return bool
+   */
+  public function valid() {
+    return $this->getIterator(true)->valid();
+  }
+
+  /** @return string */
+  public function path() {
+    $it= $this->getIterator(true);
+    return $it->valid() ? $it->key() : null;
+  }
+
+  /**
+   * Returns the current value according to the given definition
+   *
+   * @param  util.address.Definition $definition
+   * @return var
+   * @throws util.NoSuchElementException if there are no more elements
+   */
+  public function value(Definition $definition= null) {
+    $it= $this->getIterator(true);
+    if ($it->valid()) {
+      return null === $definition ? $it->current() : $it->value($definition, $this, true);
+    }
+
+    throw new NoSuchElementException('No more elements in iterator');    
+  }
+
+  /**
+   * Returns the next value according to the given definition
+   *
+   * @param  util.address.Definition $definition
+   * @return var
+   * @throws util.NoSuchElementException if there are no more elements
+   */
+  public function next(Definition $definition= null) {
+    $it= $this->getIterator(true);
+    if ($it->valid()) {
+      $value= null === $definition ? $it->current() : $it->value($definition, $this, false);
+      $it->next();
+      return $value;
+    }
+
+    throw new NoSuchElementException('No more elements in iterator');
+  }
+
+  /** @return string */
+  public function toString() {
+
+    // Most InputStream instances have a toString() method but do not implement
+    // the Value interface, see https://github.com/xp-framework/core/issues/310
+    if ($this->stream instanceof Value || method_exists($this->stream, 'toString')) {
+      return nameof($this).'<'.$this->stream->toString().'>';
+    } else {
+      return nameof($this).'<'.Objects::stringOf($this->stream).'>';
+    }
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'XS'.Objects::hashOf($this->stream);
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
+  }
+
+  /** @return void */
+  public function close() { $this->stream->close(); }
+}

--- a/src/main/php/util/address/Streaming.class.php
+++ b/src/main/php/util/address/Streaming.class.php
@@ -140,7 +140,7 @@ abstract class Streaming implements Closeable, Value, IteratorAggregate {
 
   /** @return string */
   public function hashCode() {
-    return 'XS'.Objects::hashOf($this->stream);
+    return 'S'.Objects::hashOf($this->stream);
   }
 
   /**

--- a/src/main/php/util/address/Streaming.class.php
+++ b/src/main/php/util/address/Streaming.class.php
@@ -27,7 +27,7 @@ abstract class Streaming implements Closeable, Value, IteratorAggregate {
   }
 
   /** Returns the iterator implementation */ 
-  protected abstract function iterator(): Iterator;
+  public abstract function iterator(): Iterator;
 
   /**
    * Gets iterator

--- a/src/main/php/util/address/XmlFile.class.php
+++ b/src/main/php/util/address/XmlFile.class.php
@@ -6,6 +6,7 @@ use lang\{Closeable, Value};
 /**
  * XML file input
  *
+ * @deprecated by XmlStreaming
  * @test  util.address.unittest.XmlInputTest
  */
 class XmlFile extends Address implements Closeable, Value {

--- a/src/main/php/util/address/XmlFile.class.php
+++ b/src/main/php/util/address/XmlFile.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\address;
 
-use io\File;
-use lang\{Closeable, Value};
+use Iterator;
+use io\streams\FileInputStream;
 
 /**
  * XML file input
@@ -9,8 +9,7 @@ use lang\{Closeable, Value};
  * @deprecated by XmlStreaming
  * @test  util.address.unittest.XmlInputTest
  */
-class XmlFile extends Address implements Closeable, Value {
-  private $file;
+class XmlFile extends Address {
 
   /**
    * Creates a new file-based XML input
@@ -18,34 +17,10 @@ class XmlFile extends Address implements Closeable, Value {
    * @param  string|io.Path|io.File $file
    */
   public function __construct($file) {
-    $this->file= $file instanceof File ? $file : new File($file);
+    parent::__construct(new FileInputStream($file));
   }
 
-  /** @return io.streams.InputStream */
-  protected function stream() { return $this->file->in(); }
+  /** Iterator implementation */
+  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 
-  /** @return string */
-  public function toString() {
-    return nameof($this).'<'.$this->file->toString().'>';
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return 'F'.$this->file->hashCode();
-  }
-
-  /**
-   * Comparison
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? $this->file->compareTo($value->file) : 1;
-  }
-
-  /** @return void */
-  public function close() {
-    $this->file->isOpen() && $this->file->close();
-  }
 }

--- a/src/main/php/util/address/XmlFile.class.php
+++ b/src/main/php/util/address/XmlFile.class.php
@@ -19,8 +19,4 @@ class XmlFile extends Address {
   public function __construct($file) {
     parent::__construct(new FileInputStream($file));
   }
-
-  /** Iterator implementation */
-  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
-
 }

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -277,16 +277,16 @@ class XmlIterator implements Iterator {
    * Creates value from definition.
    *
    * @param  util.address.Definition $definition
-   * @param  util.address.Address $address
+   * @param  util.address.Streaming $address
    * @param  bool $source
    * @return var
    */
-  public function value($definition, $address, $source) {
+  public function value($definition, $streaming, $source) {
     if (null === $this->token->source) {
       $token= $this->token;
 
       // Create value, storing tokens during the iteration
-      $iteration= new Iteration($address);
+      $iteration= new Iteration($streaming);
       $value= $definition->create($iteration);
 
       // Unless we are at the end of the stream, push back last token.
@@ -299,7 +299,7 @@ class XmlIterator implements Iterator {
       // Restore tokens consumed by previous iteration
       $this->tokens= array_merge($this->token->source, [$this->token], $this->tokens);
       $this->token= array_shift($this->tokens);
-      return $definition->create(new Iteration($address));
+      return $definition->create(new Iteration($streaming));
     }
   }
 

--- a/src/main/php/util/address/XmlResource.class.php
+++ b/src/main/php/util/address/XmlResource.class.php
@@ -1,6 +1,5 @@
 <?php namespace util\address;
 
-use Iterator;
 use lang\XPClass;
 use lang\reflect\Package;
 
@@ -28,8 +27,4 @@ class XmlResource extends Address {
     }
     parent::__construct($package->getResourceAsStream($name)->in());
   }
-
-  /** Iterator implementation */
-  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
-
 }

--- a/src/main/php/util/address/XmlResource.class.php
+++ b/src/main/php/util/address/XmlResource.class.php
@@ -6,6 +6,7 @@ use lang\{XPClass, Value};
 /**
  * XML class loader resource input
  *
+ * @deprecated by XmlStreaming
  * @test  util.address.unittest.XmlInputTest
  */
 class XmlResource extends Address implements Value {

--- a/src/main/php/util/address/XmlStream.class.php
+++ b/src/main/php/util/address/XmlStream.class.php
@@ -9,6 +9,7 @@ use util\Objects;
  *
  * @test  util.address.unittest.XmlStreamTest
  * @test  util.address.unittest.XmlInputTest
+ * @deprecated by XmlStreaming
  */
 class XmlStream extends Address implements Closeable, Value {
   private $in;

--- a/src/main/php/util/address/XmlStream.class.php
+++ b/src/main/php/util/address/XmlStream.class.php
@@ -1,7 +1,5 @@
 <?php namespace util\address;
 
-use Iterator;
-
 /**
  * XML stream input
  *
@@ -10,8 +8,5 @@ use Iterator;
  * @deprecated by XmlStreaming
  */
 class XmlStream extends Address {
-
-  /** Iterator implementation */
-  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 
 }

--- a/src/main/php/util/address/XmlStream.class.php
+++ b/src/main/php/util/address/XmlStream.class.php
@@ -1,8 +1,6 @@
 <?php namespace util\address;
 
-use io\streams\InputStream;
-use lang\{Closeable, Value};
-use util\Objects;
+use Iterator;
 
 /**
  * XML stream input
@@ -11,50 +9,9 @@ use util\Objects;
  * @test  util.address.unittest.XmlInputTest
  * @deprecated by XmlStreaming
  */
-class XmlStream extends Address implements Closeable, Value {
-  private $in;
+class XmlStream extends Address {
 
-  /**
-   * Creates a new stream-based XML input
-   *
-   * @param  io.streams.InputStream $in
-   */
-  public function __construct(InputStream $in) {
-    $this->in= $in;
-  }
+  /** Iterator implementation */
+  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 
-  /** @return io.streams.InputStream */
-  protected function stream() { return $this->in; }
-
-  /** @return string */
-  public function toString() {
-
-    // Most InputStream instances have a toString() method but do not implement
-    // the Value interface, see https://github.com/xp-framework/core/issues/310
-    if ($this->in instanceof Value || method_exists($this->in, 'toString')) {
-      return nameof($this).'<'.$this->in->toString().'>';
-    } else {
-      return nameof($this).'<'.Objects::stringOf($this->in).'>';
-    }
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return 'S'.Objects::hashOf($this->in);
-  }
-
-  /**
-   * Comparison
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare($this->in, $value->in) : 1;
-  }
-
-  /** @return void */
-  public function close() {
-    $this->in->close();
-  }
 }

--- a/src/main/php/util/address/XmlStreaming.class.php
+++ b/src/main/php/util/address/XmlStreaming.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\address;
 
+use Iterator;
 use io\Channel;
 use io\streams\{InputStream, MemoryInputStream};
 use lang\{Closeable, Value};
@@ -25,8 +26,8 @@ class XmlStreaming extends Address implements Closeable, Value {
     }
   }
 
-  /** @return io.streams.InputStream */
-  protected function stream() { return $this->stream; }
+  /** Iterator implementation */
+  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 
   /** @return string */
   public function toString() {

--- a/src/main/php/util/address/XmlStreaming.class.php
+++ b/src/main/php/util/address/XmlStreaming.class.php
@@ -1,0 +1,60 @@
+<?php namespace util\address;
+
+use io\Channel;
+use io\streams\{InputStream, MemoryInputStream};
+use lang\{Closeable, Value};
+use util\Objects;
+
+/**
+ * XML streaming input
+ *
+ * @test  util.address.unittest.XmlStreamingTest
+ * @test  util.address.unittest.XmlInputTest
+ */
+class XmlStreaming extends Address implements Closeable, Value {
+  private $stream;
+
+  /** @param string|io.Channel|io.streams.InputStream $source */
+  public function __construct($source) {
+    if ($source instanceof InputStream) {
+      $this->stream= $source;
+    } else if ($source instanceof Channel) {
+      $this->stream= $source->in();
+    } else {
+      $this->stream= new MemoryInputStream($source);
+    }
+  }
+
+  /** @return io.streams.InputStream */
+  protected function stream() { return $this->stream; }
+
+  /** @return string */
+  public function toString() {
+
+    // Most InputStream instances have a toString() method but do not implement
+    // the Value interface, see https://github.com/xp-framework/core/issues/310
+    if ($this->stream instanceof Value || method_exists($this->stream, 'toString')) {
+      return nameof($this).'<'.$this->stream->toString().'>';
+    } else {
+      return nameof($this).'<'.Objects::stringOf($this->stream).'>';
+    }
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'XS'.Objects::hashOf($this->stream);
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
+  }
+
+  /** @return void */
+  public function close() { $this->stream->close(); }
+}

--- a/src/main/php/util/address/XmlStreaming.class.php
+++ b/src/main/php/util/address/XmlStreaming.class.php
@@ -1,10 +1,6 @@
 <?php namespace util\address;
 
 use Iterator;
-use io\Channel;
-use io\streams\{InputStream, MemoryInputStream};
-use lang\{Closeable, Value};
-use util\Objects;
 
 /**
  * XML streaming input
@@ -12,50 +8,9 @@ use util\Objects;
  * @test  util.address.unittest.XmlStreamingTest
  * @test  util.address.unittest.XmlInputTest
  */
-class XmlStreaming extends Address implements Closeable, Value {
-  private $stream;
-
-  /** @param string|io.Channel|io.streams.InputStream $source */
-  public function __construct($source) {
-    if ($source instanceof InputStream) {
-      $this->stream= $source;
-    } else if ($source instanceof Channel) {
-      $this->stream= $source->in();
-    } else {
-      $this->stream= new MemoryInputStream($source);
-    }
-  }
+class XmlStreaming extends Address {
 
   /** Iterator implementation */
   protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 
-  /** @return string */
-  public function toString() {
-
-    // Most InputStream instances have a toString() method but do not implement
-    // the Value interface, see https://github.com/xp-framework/core/issues/310
-    if ($this->stream instanceof Value || method_exists($this->stream, 'toString')) {
-      return nameof($this).'<'.$this->stream->toString().'>';
-    } else {
-      return nameof($this).'<'.Objects::stringOf($this->stream).'>';
-    }
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return 'XS'.Objects::hashOf($this->stream);
-  }
-
-  /**
-   * Comparison
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
-  }
-
-  /** @return void */
-  public function close() { $this->stream->close(); }
 }

--- a/src/main/php/util/address/XmlStreaming.class.php
+++ b/src/main/php/util/address/XmlStreaming.class.php
@@ -8,7 +8,7 @@ use Iterator;
  * @test  util.address.unittest.XmlStreamingTest
  * @test  util.address.unittest.XmlInputTest
  */
-class XmlStreaming extends Address {
+class XmlStreaming extends Streaming {
 
   /** Iterator implementation */
   protected function iterator(): Iterator { return new XmlIterator($this->stream); }

--- a/src/main/php/util/address/XmlStreaming.class.php
+++ b/src/main/php/util/address/XmlStreaming.class.php
@@ -11,6 +11,6 @@ use Iterator;
 class XmlStreaming extends Streaming {
 
   /** Iterator implementation */
-  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
+  public function iterator(): Iterator { return new XmlIterator($this->stream); }
 
 }

--- a/src/main/php/util/address/XmlString.class.php
+++ b/src/main/php/util/address/XmlString.class.php
@@ -1,6 +1,5 @@
 <?php namespace util\address;
 
-use Iterator;
 use io\streams\MemoryInputStream;
 
 /**
@@ -19,7 +18,4 @@ class XmlString extends Address {
   public function __construct($input) {
     parent::__construct(new MemoryInputStream($input));
   }
-
-  /** Iterator implementation */
-  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 }

--- a/src/main/php/util/address/XmlString.class.php
+++ b/src/main/php/util/address/XmlString.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\address;
 
+use Iterator;
 use io\streams\MemoryInputStream;
-use lang\Value;
 
 /**
  * XML string input
@@ -9,8 +9,7 @@ use lang\Value;
  * @test  util.address.unittest.XmlInputTest
  * @deprecated by XmlStreaming
  */
-class XmlString extends Address implements Value {
-  private $input;
+class XmlString extends Address {
 
   /**
    * Creates a new file-based XML input
@@ -18,30 +17,9 @@ class XmlString extends Address implements Value {
    * @param  string $input
    */
   public function __construct($input) {
-    $this->input= $input;
+    parent::__construct(new MemoryInputStream($input));
   }
 
-  /** @return io.streams.InputStream */
-  protected function stream() { return new MemoryInputStream($this->input); }
-
-  /** @return string */
-  public function toString() {
-    $l= strlen($this->input);
-    return nameof($this).'<"'.($l > 10 ? substr($this->input, 0, 10).'..." ('.$l.' bytes)>' : $this->input.'">');
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return md5($this->input);
-  }
-
-  /**
-   * Comparison
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? $this->input <=> $value->input : 1;
-  }
+  /** Iterator implementation */
+  protected function iterator(): Iterator { return new XmlIterator($this->stream); }
 }

--- a/src/main/php/util/address/XmlString.class.php
+++ b/src/main/php/util/address/XmlString.class.php
@@ -7,6 +7,7 @@ use lang\Value;
  * XML string input
  *
  * @test  util.address.unittest.XmlInputTest
+ * @deprecated by XmlStreaming
  */
 class XmlString extends Address implements Value {
   private $input;

--- a/src/test/php/util/address/unittest/AddressTest.class.php
+++ b/src/test/php/util/address/unittest/AddressTest.class.php
@@ -3,7 +3,7 @@
 use lang\{IllegalStateException, Runnable};
 use test\{Assert, Expect, Ignore, Test};
 use util\NoSuchElementException;
-use util\address\{ArrayOf, CreationOf, Definition, XmlString};
+use util\address\{ArrayOf, CreationOf, Definition, XmlStreaming};
 
 class AddressTest {
 
@@ -16,53 +16,53 @@ class AddressTest {
 
   #[Test]
   public function path() {
-    $address= new XmlString('<doc/>');
+    $address= new XmlStreaming('<doc/>');
     Assert::equals('/', $address->path());
   }
 
   #[Test]
   public function path_after_end() {
-    $address= new XmlString('<doc/>');
+    $address= new XmlStreaming('<doc/>');
     $address->next();
     Assert::null($address->path());
   }
 
   #[Test]
   public function empty_node_value() {
-    $address= new XmlString('<doc/>');
+    $address= new XmlStreaming('<doc/>');
     Assert::null($address->next());
   }
 
   #[Test]
   public function value_for_node_with_content() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals('Test', $address->next());
   }
 
   #[Test, Expect(NoSuchElementException::class)]
   public function next_after_end() {
-    $address= new XmlString('<doc/>');
+    $address= new XmlStreaming('<doc/>');
     $address->next();
     $address->next();
   }
 
   #[Test, Expect(NoSuchElementException::class)]
   public function value_after_end() {
-    $address= new XmlString('<doc/>');
+    $address= new XmlStreaming('<doc/>');
     $address->next();
     $address->value();
   }
 
   #[Test]
   public function next_after_resetting() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     $address->reset();
     Assert::equals('Test', $address->next());
   }
 
   #[Test]
   public function next_after_next_and_resetting() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     $address->next();
     $address->reset();
     Assert::equals('Test', $address->next());
@@ -70,40 +70,40 @@ class AddressTest {
 
   #[Test]
   public function value() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals('Test', $address->value());
   }
 
   #[Test]
   public function valid() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::true($address->valid());
   }
 
   #[Test]
   public function valid_after_end() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     $address->next();
     Assert::false($address->valid());
   }
 
   #[Test]
   public function valid_after_resetting() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     $address->reset();
     Assert::true($address->valid());
   }
 
   #[Test]
   public function valid_after_value() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     $address->value();
     Assert::true($address->valid());
   }
 
   #[Test]
   public function valid_after_next_and_resetting() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     $address->next();
     $address->reset();
     Assert::true($address->valid());
@@ -111,7 +111,7 @@ class AddressTest {
 
   #[Test]
   public function iteration() {
-    $address= new XmlString('<doc><nested>Test</nested></doc>');
+    $address= new XmlStreaming('<doc><nested>Test</nested></doc>');
     $actual= [];
     while ($address->valid()) {
       $actual[]= [$address->path() => $address->next()];
@@ -121,13 +121,13 @@ class AddressTest {
 
   #[Test]
   public function next_with_definition() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals(['/' => 'Test'], $address->next($this->asMap()));
   }
 
   #[Test]
   public function value_with_definition() {
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals(['/' => 'Test'], $address->value($this->asMap()));
   }
 
@@ -135,7 +135,7 @@ class AddressTest {
   public function repeated_value_with_definition() {
     $definition= $this->asMap();
 
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals(['/' => 'Test'], $address->value($definition), '#1');
     Assert::equals(['/' => 'Test'], $address->value($definition), '#2');
   }
@@ -144,7 +144,7 @@ class AddressTest {
   public function next_after_value_with_definition() {
     $definition= $this->asMap();
 
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals(['/' => 'Test'], $address->value($definition), '#1');
     Assert::equals(['/' => 'Test'], $address->next($definition), '#2');
   }
@@ -155,27 +155,27 @@ class AddressTest {
       public function create($it) { return $it->next(); }
     };
 
-    $address= new XmlString('<doc>Test</doc>');
+    $address= new XmlStreaming('<doc>Test</doc>');
     Assert::equals(['/' => 'Test'], $address->value($this->asMap()), '#1');
     Assert::equals('Test', $address->value($asValue), '#2');
   }
 
   #[Test]
   public function iteration_support() {
-    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address= new XmlStreaming('<doc><a>A</a><b>B</b></doc>');
     Assert::equals(['/' => null, '//a' => 'A', '//b' => 'B'], iterator_to_array($address));
   }
 
   #[Test]
   public function iteration_support_for_empty_document() {
-    $address= new XmlString('<doc/>');
+    $address= new XmlStreaming('<doc/>');
     Assert::equals(['/' => null], iterator_to_array($address));
   }
 
   #[Test]
   public function iteration_valid_with_value() {
     $actual= [];
-    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address= new XmlStreaming('<doc><a>A</a><b>B</b></doc>');
     foreach ($address as $path => $value) {
       $actual[$path]= [$address->value(), $address->valid()];
     }
@@ -189,7 +189,7 @@ class AddressTest {
     };
 
     $actual= [];
-    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address= new XmlStreaming('<doc><a>A</a><b>B</b></doc>');
     foreach ($address as $path => $value) {
       $actual[$path]= [$address->value($definition), $address->valid()];
     }
@@ -200,7 +200,7 @@ class AddressTest {
   public function pointers() {
     $actual= [];
 
-    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address= new XmlStreaming('<doc><a>A</a><b>B</b></doc>');
     foreach ($address->pointers() as $path => $pointer) {
       $actual[$path]= $pointer->value();
     }
@@ -211,7 +211,7 @@ class AddressTest {
   public function filtered_pointers() {
     $actual= [];
 
-    $address= new XmlString('<tests><unit>A</unit><unit>B</unit><integration>C</integration></tests>');
+    $address= new XmlStreaming('<tests><unit>A</unit><unit>B</unit><integration>C</integration></tests>');
     foreach ($address->pointers('//unit') as $path => $pointer) {
       $actual[]= $pointer->value();
     }
@@ -223,7 +223,7 @@ class AddressTest {
     $definition= $this->asMap();
     $actual= [];
 
-    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address= new XmlStreaming('<doc><a>A</a><b>B</b></doc>');
     foreach ($address->pointers() as $path => $pointer) {
       $actual+= $pointer->value($definition);
     }
@@ -234,7 +234,7 @@ class AddressTest {
   public function pointers_can_resume() {
     $actual= [];
 
-    $address= new XmlString('<doc><a>A</a><b>B</b></doc>');
+    $address= new XmlStreaming('<doc><a>A</a><b>B</b></doc>');
     $address->next();
     foreach ($address->pointers() as $path => $pointer) {
       $actual[$path]= $pointer->value();

--- a/src/test/php/util/address/unittest/ObjectOfTest.class.php
+++ b/src/test/php/util/address/unittest/ObjectOfTest.class.php
@@ -3,12 +3,12 @@
 use lang\{ClassLoader, Error, IllegalArgumentException, IllegalStateException, Runnable, XPClass};
 use test\verify\Runtime;
 use test\{Action, Assert, Expect, Test, Values};
-use util\address\{ObjectOf, XmlString};
+use util\address\{ObjectOf, XmlStreaming};
 
 class ObjectOfTest {
 
   /** @return util.address.Address */
-  private function address() { return new XmlString('<book author="Test">Name</book>'); }
+  private function address() { return new XmlStreaming('<book author="Test">Name</book>'); }
 
   /** Fixture for can_use_public_methods_from_this() test */
   public function toUpper(string $in): string { return strtoupper($in); }

--- a/src/test/php/util/address/unittest/RecordOfTest.class.php
+++ b/src/test/php/util/address/unittest/RecordOfTest.class.php
@@ -3,12 +3,12 @@
 use lang\{Error, IllegalArgumentException, Runnable, XPClass};
 use test\verify\Runtime;
 use test\{Action, Assert, Expect, Test, Values};
-use util\address\{RecordOf, XmlString};
+use util\address\{RecordOf, XmlStreaming};
 
 class RecordOfTest {
 
   /** @return util.address.Address */
-  private function address() { return new XmlString('<book author="Test">Name</book>'); }
+  private function address() { return new XmlStreaming('<book author="Test">Name</book>'); }
 
   /** @return iterable */
   private function types() {

--- a/src/test/php/util/address/unittest/StreamingTest.class.php
+++ b/src/test/php/util/address/unittest/StreamingTest.class.php
@@ -5,7 +5,7 @@ use test\{Assert, Expect, Ignore, Test};
 use util\NoSuchElementException;
 use util\address\{ArrayOf, CreationOf, Definition, XmlStreaming};
 
-class AddressTest {
+class StreamingTest {
 
   /** @return util.address.Definition */
   private function asMap() {

--- a/src/test/php/util/address/unittest/UsingNextTest.class.php
+++ b/src/test/php/util/address/unittest/UsingNextTest.class.php
@@ -2,7 +2,7 @@
 
 use test\verify\Runtime;
 use test\{Action, Assert, Test};
-use util\address\{ValueOf, XmlString};
+use util\address\{ValueOf, XmlStreaming};
 
 /** @deprecated */
 class UsingNextTest {
@@ -10,7 +10,7 @@ class UsingNextTest {
 
   #[Test]
   public function next_without_definition() {
-    $address= new XmlString(self::BOOK);
+    $address= new XmlStreaming(self::BOOK);
     Assert::equals(
       ['name' => 'Name'],
       $address->next(new ValueOf([], [
@@ -22,7 +22,7 @@ class UsingNextTest {
 
   #[Test]
   public function next_with_definition() {
-    $address= new XmlString(self::BOOK);
+    $address= new XmlStreaming(self::BOOK);
     Assert::equals(
       ['name' => 'Name', 'author' => null, 'date' => '1977-12-14'],
       $address->next(new ValueOf([], [
@@ -39,7 +39,7 @@ class UsingNextTest {
   /** @see https://wiki.php.net/rfc/arrow_functions_v2 */
   #[Test, Runtime(php: '>=7.4')]
   public function can_use_fn() {
-    $address= new XmlString(self::BOOK);
+    $address= new XmlStreaming(self::BOOK);
     Assert::equals(
       ['name' => 'Name'],
       $address->next(new ValueOf([], [

--- a/src/test/php/util/address/unittest/XmlInputTest.class.php
+++ b/src/test/php/util/address/unittest/XmlInputTest.class.php
@@ -2,7 +2,7 @@
 
 use test\{Assert, Test, Values};
 use util\Date;
-use util\address\{ObjectOf, XmlStreaming};
+use util\address\{ObjectOf, XmlStreaming, XmlResource};
 
 class XmlInputTest {
 
@@ -12,7 +12,8 @@ class XmlInputTest {
     return [
       [new XmlStreaming($package->getResource('releases.xml'))],
       [new XmlStreaming($package->getResourceAsStream('releases.xml')->in())],
-      [new XmlStreaming($package->getResourceAsStream('releases.xml'))]
+      [new XmlStreaming($package->getResourceAsStream('releases.xml'))],
+      [new XmlResource($package, 'releases.xml')] // deprecated!
     ];
   }
 

--- a/src/test/php/util/address/unittest/XmlInputTest.class.php
+++ b/src/test/php/util/address/unittest/XmlInputTest.class.php
@@ -2,18 +2,17 @@
 
 use test\{Assert, Test, Values};
 use util\Date;
-use util\address\{ObjectOf, XmlFile, XmlResource, XmlStream, XmlString};
+use util\address\{ObjectOf, XmlStreaming};
 
 class XmlInputTest {
 
   /** @return var[][] */
   protected function inputs() {
-    $t= typeof($this);
+    $package= typeof($this)->getPackage();
     return [
-      [new XmlString($t->getPackage()->getResource('releases.xml'))],
-      [new XmlStream($t->getPackage()->getResourceAsStream('releases.xml')->in())],
-      [new XmlFile($t->getPackage()->getResourceAsStream('releases.xml'))],
-      [new XmlResource($t, 'releases.xml')]
+      [new XmlStreaming($package->getResource('releases.xml'))],
+      [new XmlStreaming($package->getResourceAsStream('releases.xml')->in())],
+      [new XmlStreaming($package->getResourceAsStream('releases.xml'))]
     ];
   }
 

--- a/src/test/php/util/address/unittest/XmlStreamingTest.class.php
+++ b/src/test/php/util/address/unittest/XmlStreamingTest.class.php
@@ -2,19 +2,18 @@
 
 use io\streams\MemoryInputStream;
 use test\{Assert, Test};
-use util\address\XmlStream;
+use util\address\XmlStreaming;
 
-/** @deprecated by XmlStreamingTest */
-class XmlStreamTest {
+class XmlStreamingTest {
 
   /**
    * Creates a new fixture
    *
    * @param  string $bytes
-   * @return util.address.XmlStream
+   * @return util.address.XmlStreaming
    */
   private function fixture($bytes= '') {
-    return new XmlStream(new MemoryInputStream($bytes));
+    return new XmlStreaming(new MemoryInputStream($bytes));
   }
 
   #[Test]
@@ -30,7 +29,7 @@ class XmlStreamTest {
   #[Test]
   public function string_representation() {
     Assert::equals(
-      'util.address.XmlStream<io.streams.MemoryInputStream(@0 of 4 bytes)>',
+      'util.address.XmlStreaming<io.streams.MemoryInputStream(@0 of 4 bytes)>',
       $this->fixture('Test')->toString()
     );
   }
@@ -54,7 +53,7 @@ class XmlStreamTest {
       public function close() { $this->closed= true; }
     };
 
-    $fixture= new XmlStream($stream);
+    $fixture= new XmlStreaming($stream);
     $fixture->close();
 
     Assert::true($stream->closed);


### PR DESCRIPTION
This pull request deprecates *XmlStream*, *XmlFile*, *XmlString* and *XmlResource* in favor of a new class, `util.address.XmlStreaming`, and introduces a new base class, `util.address.Streaming`. This way, it becomes easier to stream other formats, e.g. by implementing a class `util.address.JsonStreaming`.

## Before

Every input source has a different (but 90% identical) implementation:

```php
use util\address\{XmlStream, XmlFile, XmlString};

$stream= new XmlStream($socket->in());
$stream= new XmlFile(new File('...'));
$stream= new XmlString('<root>...</root>');
$stream= new XmlResource($package, 'releases.xml');
```

## After

The *XmlStreaming* constructor accepts `string|io.Channel|io.streams.InputStream` as source, and can handle all cases:

```php
use util\address\XmlStreaming;

$stream= new XmlStreaming($socket->in());    // or also new XmlStreaming($socket);
$stream= new XmlStreaming(new File('...'));
$stream= new XmlStreaming('<root>...</root>');
$stream= new XmlStreaming($package->getResourceAsStream('releases.xml'));
```

## Deprecations

The following classes are marked as deprecated and will be removed in the next major release.

```bash
$ grep -Hrn @deprecated src/main/php/
src/main/php/util/address/Address.class.php:8: * @deprecated Inherit from util.address.Streaming instead!
src/main/php/util/address/XmlFile.class.php:9: * @deprecated by XmlStreaming
src/main/php/util/address/XmlResource.class.php:9: * @deprecated by XmlStreaming
src/main/php/util/address/XmlStream.class.php:8: * @deprecated by XmlStreaming
src/main/php/util/address/XmlString.class.php:9: * @deprecated by XmlStreaming
```