### PR TITLE
Handle `xml:space` attribute & preserve whitespace

### DIFF
--- a/src/main/php/util/address/Token.class.php
+++ b/src/main/php/util/address/Token.class.php
@@ -3,6 +3,7 @@
 class Token {
   public $path, $content;
   public $source= null;
+  public $space= false;
 
   /**
    * Creates a new token

--- a/src/main/php/util/address/XmlIterator.class.php
+++ b/src/main/php/util/address/XmlIterator.class.php
@@ -74,10 +74,14 @@ class XmlIterator implements Iterator {
     }
 
     $this->node= sizeof($this->tokens);
-    $this->tokens[]= new Token($this->path, null);
+    $this->tokens[]= $token= new Token($this->path, null);
     if ('' !== trim($attr)) {
       foreach ($this->attributesIn($attr) as $name => $value) {
-        $this->tokens[]= new Token($this->path.'/@'.$name, $value);
+        if ('xml:space' === $name) {
+          $token->space= 'preserve' === $value;
+        } else {
+          $this->tokens[]= new Token($this->path.'/@'.$name, $value);
+        }
       }
     }
     $this->valid= true;
@@ -90,8 +94,8 @@ class XmlIterator implements Iterator {
    * @return void
    */
   protected function cdata($content) {
-    if ($this->tokens) {
-      $this->tokens[$this->node]->content.= $content;
+    if ($token= $this->tokens[$this->node] ?? null) {
+      $token->content.= $content;
     }
   }
 
@@ -102,8 +106,10 @@ class XmlIterator implements Iterator {
    * @return void
    */
   protected function pcdata($content) {
-    if ($this->tokens && '' !== ($t= trim($content))) {
-      $this->tokens[$this->node]->content.= $t;
+    if ($token= $this->tokens[$this->node] ?? null) {
+      if ('' !== ($t= $token->space ? $content : trim($content))) {
+        $token->content.= $t;
+      }
     }
   }
 

--- a/src/test/php/util/address/unittest/XmlIteratorTest.class.php
+++ b/src/test/php/util/address/unittest/XmlIteratorTest.class.php
@@ -106,6 +106,22 @@ class XmlIteratorTest {
     );
   }
 
+  #[Test, Values(['A ', ' A', ' A '])]
+  public function whitespace($content) {
+    $this->assertIterated(
+      [['/' => 'A']],
+      new XmlIterator(new MemoryInputStream("<test>{$content}</test>"))
+    );
+  }
+
+  #[Test, Values(['A ', ' A', ' A '])]
+  public function preserve_whitespace($content) {
+    $this->assertIterated(
+      [['/' => $content]],
+      new XmlIterator(new MemoryInputStream("<test xml:space=\"preserve\">{$content}</test>"))
+    );
+  }
+
   #[Test]
   public function entities_from_doctype() {
     $this->assertIterated(


### PR DESCRIPTION
See https://www.w3.org/TR/REC-xml/#sec-white-space:

> In editing XML documents, it is often convenient to use "white space" (spaces, tabs, and blank lines) to set apart the markup for greater readability. Such white space is typically not intended for inclusion in the delivered version of the document. On the other hand, "significant" white space that should be preserved in the delivered version is common, for example in poetry and source code.
> [...]
>
> When declared, it must be given as an enumerated type whose values are one or both of "default" and "preserve"